### PR TITLE
Add retries if the stratum hostname is not found

### DIFF
--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -18,7 +18,7 @@
 
 static const char *TAG = "stratum_task";
 static ip_addr_t ip_Addr;
-static bool bDNSFound = false;
+static uint8_t bDNSFound = 0;
 
 static StratumApiV1Message stratum_api_v1_message = {};
 
@@ -27,8 +27,15 @@ static SystemTaskModule SYSTEM_TASK_MODULE = {
 
 void dns_found_cb(const char *name, const ip_addr_t *ipaddr, void *callback_arg)
 {
-    ip_Addr = *ipaddr;
-    bDNSFound = true;
+    if(ipaddr != NULL)
+    {
+        ip_Addr = *ipaddr;
+        bDNSFound = 1;
+    }
+    else
+    {
+        bDNSFound= -1;
+    }
 }
 
 void stratum_task(void *pvParameters)
@@ -46,7 +53,7 @@ void stratum_task(void *pvParameters)
     // check to see if the STRATUM_URL is an ip address already
     if (inet_pton(AF_INET, stratum_url, &ip_Addr) == 1)
     {
-        bDNSFound = true;
+        bDNSFound = 1;
     }
     else
     {
@@ -54,8 +61,17 @@ void stratum_task(void *pvParameters)
         IP_ADDR4(&ip_Addr, 0, 0, 0, 0);
         ESP_LOGI(TAG, "Get IP for URL: %s\n", stratum_url);
         dns_gethostbyname(stratum_url, &ip_Addr, dns_found_cb, NULL);
-        while (!bDNSFound)
-            ;
+        while (true)
+        {
+            vTaskDelay(500 / portTICK_PERIOD_MS);
+
+            //try again
+            if (bDNSFound == -1)
+                dns_gethostbyname(stratum_url, &ip_Addr, dns_found_cb, NULL);
+
+            if(bDNSFound == 1)
+                break;
+        }
     }
 
     // make IP address string from ip_Addr

--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -18,7 +18,7 @@
 
 static const char *TAG = "stratum_task";
 static ip_addr_t ip_Addr;
-static uint8_t bDNSFound = 0;
+static int8_t bDNSFound = 0;
 
 static StratumApiV1Message stratum_api_v1_message = {};
 


### PR DESCRIPTION
After restoring the Wi-Fi connection, the router may still try to connect to the internet. Therefore, it will fail to solve the IP address, and then the *ipaddr returns a NULL pointer.