### PR TITLE
Get ASIC model from NVS

### DIFF
--- a/components/stratum/include/stratum_api.h
+++ b/components/stratum/include/stratum_api.h
@@ -57,7 +57,7 @@ void STRATUM_V1_initialize_buffer();
 
 char *STRATUM_V1_receive_jsonrpc_line(int sockfd);
 
-int STRATUM_V1_subscribe(int socket, char **extranonce, int *extranonce2_len);
+int STRATUM_V1_subscribe(int socket, char ** extranonce, int * extranonce2_len, char * model);
 
 void STRATUM_V1_parse(StratumApiV1Message *message, const char *stratum_json);
 

--- a/components/stratum/stratum_api.c
+++ b/components/stratum/stratum_api.c
@@ -266,14 +266,14 @@ int _parse_stratum_subscribe_result_message(const char *result_json_str,
     return 0;
 }
 
-int STRATUM_V1_subscribe(int socket, char **extranonce, int *extranonce2_len)
+int STRATUM_V1_subscribe(int socket, char ** extranonce, int * extranonce2_len, char * model)
 {
     // Subscribe
     char subscribe_msg[BUFFER_SIZE];
-    sprintf(subscribe_msg, "{\"id\": %d, \"method\": \"mining.subscribe\", \"params\": [\"bitaxe %s\"]}\n", send_uid++, CONFIG_ASIC_MODEL);
+    sprintf(subscribe_msg, "{\"id\": %d, \"method\": \"mining.subscribe\", \"params\": [\"bitaxe %s\"]}\n", send_uid++, model);
     debug_stratum_tx(subscribe_msg);
     write(socket, subscribe_msg, strlen(subscribe_msg));
-    char *line;
+    char * line;
     line = STRATUM_V1_receive_jsonrpc_line(socket);
 
     ESP_LOGI(TAG, "Received result %s", line);

--- a/config.cvs.example
+++ b/config.cvs.example
@@ -6,8 +6,8 @@ stratumurl,data,string,public-pool.io
 stratumport,data,u16,21496
 stratumuser,data,string,1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa.bitaxe
 stratumpass,data,string,x
-asicfrequency,data,u16,450
-asicvoltage,data,u16,1400
+asicfrequency,data,u16,485
+asicvoltage,data,u16,1320
 asicmodel,data,string,BM1366
 devicemodel,data,string,ultra
 boardversion,data,string,0.11

--- a/config.cvs.example
+++ b/config.cvs.example
@@ -8,3 +8,6 @@ stratumuser,data,string,1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa.bitaxe
 stratumpass,data,string,x
 asicfrequency,data,u16,450
 asicvoltage,data,u16,1400
+asicmodel,data,string,BM1366
+devicemodel,data,string,ultra
+boardversion,data,string,0.11

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -1,11 +1,4 @@
 menu "Bitaxe Configuration"
-
-    config ASIC_MODEL
-        string "ASIC Model"
-        default "BM1397"
-        help
-            BM1397 or BM1366
-
     config ASIC_VOLTAGE
         int "ASIC Core Voltage (mV)"
         range 1000 1800

--- a/main/global_state.h
+++ b/main/global_state.h
@@ -1,29 +1,30 @@
 #ifndef GLOBAL_STATE_H_
 #define GLOBAL_STATE_H_
 
-#include "work_queue.h"
-#include "bm1397.h"
-#include "bm1366.h"
-#include "system.h"
-#include "stratum_api.h"
 #include "asic_task.h"
+#include "bm1366.h"
+#include "bm1397.h"
+#include "common.h"
 #include "power_management_task.h"
 #include "serial.h"
-#include "common.h"
+#include "stratum_api.h"
+#include "system.h"
+#include "work_queue.h"
 
 #define STRATUM_USER CONFIG_STRATUM_USER
 
 typedef struct
 {
     void (*init_fn)(u_int64_t);
-    task_result *(*receive_result_fn)(void *GLOBAL_STATE);
+    task_result * (*receive_result_fn)(void * GLOBAL_STATE);
     int (*set_max_baud_fn)(void);
     void (*set_difficulty_mask_fn)(int);
-    void (*send_work_fn)(void *GLOBAL_STATE, bm_job *next_bm_job);
+    void (*send_work_fn)(void * GLOBAL_STATE, bm_job * next_bm_job);
 } AsicFunctions;
 
 typedef struct
 {
+    char * asic_model;
     AsicFunctions ASIC_functions;
     double asic_job_frequency_ms;
 
@@ -35,11 +36,11 @@ typedef struct
     AsicTaskModule ASIC_TASK_MODULE;
     PowerManagementModule POWER_MANAGEMENT_MODULE;
 
-    char *extranonce_str;
+    char * extranonce_str;
     int extranonce_2_len;
     int abandon_work;
 
-    uint8_t *valid_jobs;
+    uint8_t * valid_jobs;
     pthread_mutex_t valid_jobs_lock;
 
     uint32_t stratum_difficulty;

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -258,7 +258,7 @@ static esp_err_t GET_system_info(httpd_req_t * req)
     cJSON_AddNumberToObject(root, "sharesAccepted", GLOBAL_STATE->SYSTEM_MODULE.shares_accepted);
     cJSON_AddNumberToObject(root, "sharesRejected", GLOBAL_STATE->SYSTEM_MODULE.shares_rejected);
     cJSON_AddNumberToObject(root, "uptimeSeconds", (esp_timer_get_time() - GLOBAL_STATE->SYSTEM_MODULE.start_time) / 1000000);
-    cJSON_AddStringToObject(root, "ASICModel", CONFIG_ASIC_MODEL);
+    cJSON_AddStringToObject(root, "ASICModel", GLOBAL_STATE->asic_model);
     cJSON_AddStringToObject(root, "stratumURL", stratumURL);
     cJSON_AddNumberToObject(root, "stratumPort", nvs_config_get_u16(NVS_CONFIG_STRATUM_PORT, CONFIG_STRATUM_PORT));
     cJSON_AddStringToObject(root, "stratumUser", stratumUser);

--- a/main/main.c
+++ b/main/main.c
@@ -17,8 +17,6 @@
 #include "stratum_task.h"
 #include "user_input_task.h"
 
-#define ASIC_MODEL CONFIG_ASIC_MODEL
-
 static GlobalState GLOBAL_STATE = {.extranonce_str = NULL, .extranonce_2_len = 0, .abandon_work = 0, .version_mask = 0};
 
 static const char * TAG = "miner";
@@ -30,7 +28,8 @@ void app_main(void)
     ESP_LOGI(TAG, "NVS_CONFIG_ASIC_FREQ %f", (float) nvs_config_get_u16(NVS_CONFIG_ASIC_FREQ, CONFIG_ASIC_FREQUENCY));
     GLOBAL_STATE.POWER_MANAGEMENT_MODULE.frequency_value = nvs_config_get_u16(NVS_CONFIG_ASIC_FREQ, CONFIG_ASIC_FREQUENCY);
 
-    if (strcmp(ASIC_MODEL, "BM1366") == 0) {
+    GLOBAL_STATE.asic_model = nvs_config_get_string(NVS_CONFIG_ASIC_MODEL, "");
+    if (strcmp(GLOBAL_STATE.asic_model, "BM1366") == 0) {
         ESP_LOGI(TAG, "ASIC: BM1366");
         AsicFunctions ASIC_functions = {.init_fn = BM1366_init,
                                         .receive_result_fn = BM1366_proccess_work,
@@ -40,7 +39,7 @@ void app_main(void)
         GLOBAL_STATE.asic_job_frequency_ms = BM1366_FULLSCAN_MS;
 
         GLOBAL_STATE.ASIC_functions = ASIC_functions;
-    } else if (strcmp(ASIC_MODEL, "BM1397") == 0) {
+    } else if (strcmp(GLOBAL_STATE.asic_model, "BM1397") == 0) {
         ESP_LOGI(TAG, "ASIC: BM1397");
         AsicFunctions ASIC_functions = {.init_fn = BM1397_init,
                                         .receive_result_fn = BM1397_proccess_work,
@@ -53,7 +52,7 @@ void app_main(void)
 
         GLOBAL_STATE.ASIC_functions = ASIC_functions;
     } else {
-        ESP_LOGI(TAG, "Invalid ASIC model");
+        ESP_LOGE(TAG, "Unable to determine ASIC model. Please make sure the model has been written into NVS.");
         exit(EXIT_FAILURE);
     }
 

--- a/main/main.c
+++ b/main/main.c
@@ -52,7 +52,8 @@ void app_main(void)
 
         GLOBAL_STATE.ASIC_functions = ASIC_functions;
     } else {
-        ESP_LOGE(TAG, "Unable to determine ASIC model. Please make sure the model has been written into NVS.");
+        ESP_LOGE(TAG, "Unable to determine ASIC model. Please make sure the model has been written into NVS at main/asicmodel.");
+        vTaskDelay(10000 / portTICK_PERIOD_MS);
         exit(EXIT_FAILURE);
     }
 

--- a/main/nvs_config.h
+++ b/main/nvs_config.h
@@ -11,11 +11,13 @@
 #define NVS_CONFIG_STRATUM_PASS "stratumpass"
 #define NVS_CONFIG_ASIC_FREQ "asicfrequency"
 #define NVS_CONFIG_ASIC_VOLTAGE "asicvoltage"
-#define NVS_CONFIG_ASIC_MODEL "asicModel"
+#define NVS_CONFIG_ASIC_MODEL "asicmodel"
+#define NVS_CONFIG_DEVICE_MODEL "devicemodel"
+#define NVS_CONFIG_BOARD_VERSION "boardversion"
 
-char *nvs_config_get_string(const char *key, const char *default_value);
-void nvs_config_set_string(const char *key, const char *default_value);
-uint16_t nvs_config_get_u16(const char *key, const uint16_t default_value);
-void nvs_config_set_u16(const char *key, const uint16_t value);
+char * nvs_config_get_string(const char * key, const char * default_value);
+void nvs_config_set_string(const char * key, const char * default_value);
+uint16_t nvs_config_get_u16(const char * key, const uint16_t default_value);
+void nvs_config_set_u16(const char * key, const uint16_t value);
 
 #endif // MAIN_NVS_CONFIG_H

--- a/main/system.c
+++ b/main/system.c
@@ -29,14 +29,12 @@
 
 static const char * TAG = "SystemModule";
 
-#define ASIC_MODEL CONFIG_ASIC_MODEL
-
 static void _suffix_string(uint64_t, char *, size_t, int);
 
 static esp_netif_t * netif;
 static esp_netif_ip_info_t ip_info;
 
-static void _init_system(SystemModule * module)
+static void _init_system(GlobalState * global_state, SystemModule * module)
 {
     module->duration_start = 0;
     module->historical_hashrate_rolling_index = 0;
@@ -80,7 +78,7 @@ static void _init_system(SystemModule * module)
 
     // Fan Tests
     EMC2101_init();
-    if (strcmp(ASIC_MODEL, "BM1366") == 0) {
+    if (strcmp(global_state->asic_model, "BM1366") == 0) {
         EMC2101_set_fan_speed(0);
     } else {
         EMC2101_set_fan_speed(1);
@@ -336,7 +334,7 @@ void SYSTEM_task(void * pvParameters)
     GlobalState * GLOBAL_STATE = (GlobalState *) pvParameters;
     SystemModule * module = &GLOBAL_STATE->SYSTEM_MODULE;
 
-    _init_system(module);
+    _init_system(GLOBAL_STATE, module);
 
     _clear_display();
     _init_connection(module);

--- a/main/tasks/power_management_task.c
+++ b/main/tasks/power_management_task.c
@@ -20,7 +20,6 @@
 #define VOLTAGE_START_THROTTLE 4900
 #define VOLTAGE_MIN_THROTTLE 3500
 #define VOLTAGE_RANGE (VOLTAGE_START_THROTTLE - VOLTAGE_MIN_THROTTLE)
-#define ASIC_MODEL CONFIG_ASIC_MODEL
 
 static const char * TAG = "power_management";
 
@@ -58,7 +57,7 @@ void POWER_MANAGEMENT_task(void * pvParameters)
         }
         power_management->fan_speed = EMC2101_get_fan_speed();
 
-        if (strcmp(ASIC_MODEL, "BM1397") == 0) {
+        if (strcmp(GLOBAL_STATE->asic_model, "BM1397") == 0) {
 
             power_management->chip_temp = EMC2101_get_external_temp();
 
@@ -115,7 +114,7 @@ void POWER_MANAGEMENT_task(void * pvParameters)
                     last_frequency_increase++;
                 }
             }
-        } else if (strcmp(ASIC_MODEL, "BM1366") == 0) {
+        } else if (strcmp(GLOBAL_STATE->asic_model, "BM1366") == 0) {
             power_management->chip_temp = EMC2101_get_internal_temp() + 5;
 
             if (power_management->fan_speed < 10) {

--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -93,7 +93,8 @@ void stratum_task(void *pvParameters)
             break;
         }
 
-        STRATUM_V1_subscribe(GLOBAL_STATE->sock, &GLOBAL_STATE->extranonce_str, &GLOBAL_STATE->extranonce_2_len);
+        STRATUM_V1_subscribe(GLOBAL_STATE->sock, &GLOBAL_STATE->extranonce_str, &GLOBAL_STATE->extranonce_2_len,
+                             GLOBAL_STATE->asic_model);
 
         STRATUM_V1_configure_version_rolling(GLOBAL_STATE->sock);
 


### PR DESCRIPTION
By having the asic model written into flash, we can distribute a single release binary. This will prevent users from uploading the wrong firmware type. The ASIC model can be written into flash using bitaxetool.

```
pip install --upgrade bitaxetool==0.4
cp config.cvs.example config.cvs
vim config.cvs
bitaxetool --port /dev/ttyACM1 --config ./config.cvs
```