### PR TITLE
main: Build the web ui dist as an ExternalProject

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,13 +5,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Setup Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '20'
     - name: Build web dist
       working-directory: ./main/http_server/axe-os
       run: |
@@ -22,6 +22,7 @@ jobs:
       with:
         esp_idf_version: v5.1
         target: esp32s2
+        command: GITHUB_ACTIONS="true" idf.py build
         path: '.'
     - name: upload esp-miner.bin
       uses: actions/upload-artifact@v3

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -27,9 +27,37 @@ INCLUDE_DIRS
 )
 
 set(WEB_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/http_server/axe-os")
-if(EXISTS ${WEB_SRC_DIR}/dist/axe-os)
+
+if("$ENV{GITHUB_ACTIONS}" STREQUAL "true")
+    message(STATUS "Running on GitHub Actions. Web ui will be prebuilt.")
+
     spiffs_create_partition_image(www ${WEB_SRC_DIR}/dist/axe-os FLASH_IN_PROJECT)
 else()
-    message(FATAL_ERROR "${WEB_SRC_DIR}/dist doesn't exit. Please run 'npm i && npm run build' in ${WEB_SRC_DIR}")
+    find_program(NPM_EXECUTABLE npm)
+    if(NOT NPM_EXECUTABLE AND NOT EXISTS ${WEB_SRC_DIR}/dist)
+        message(FATAL_ERROR "npm is not found! Please install it to proceed.")
+    endif()
 
+    ExternalProject_Add(
+        web_ui_dist
+        PREFIX ${CMAKE_BINARY_DIR}/web_ui_dist
+        SOURCE_DIR ${WEB_SRC_DIR}
+        DOWNLOAD_COMMAND ""
+        CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env
+            PATH=$ENV{PATH}
+            ${NPM_EXECUTABLE}  i
+        USES_TERMINAL_BUILD true
+        BUILD_COMMAND ${CMAKE_COMMAND} -E env
+            PATH=$ENV{PATH}
+            ${NPM_EXECUTABLE} run build
+        INSTALL_COMMAND ""
+        BUILD_ALWAYS OFF
+        BUILD_IN_SOURCE TRUE
+        BUILD_BYPRODUCTS
+            "${WEB_SRC_DIR}/dist/axe-os/index.html"
+    )
+
+    add_dependencies(${COMPONENT_LIB} web_ui_dist)
+
+    spiffs_create_partition_image(www ${WEB_SRC_DIR}/dist/axe-os FLASH_IN_PROJECT DEPENDS web_ui_dist)
 endif()


### PR DESCRIPTION
This integrates the generation of the web distribution into the cmake build system. The ExternalProject will call npm i and npm run build.

Resolves #34