### PR TITLE
Fixes mining.configure order #50

### DIFF
--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -93,10 +93,10 @@ void stratum_task(void *pvParameters)
             break;
         }
 
+        STRATUM_V1_configure_version_rolling(GLOBAL_STATE->sock);
+
         STRATUM_V1_subscribe(GLOBAL_STATE->sock, &GLOBAL_STATE->extranonce_str, &GLOBAL_STATE->extranonce_2_len,
                              GLOBAL_STATE->asic_model);
-
-        STRATUM_V1_configure_version_rolling(GLOBAL_STATE->sock);
 
         char *username = nvs_config_get_string(NVS_CONFIG_STRATUM_USER, STRATUM_USER);
         STRATUM_V1_authenticate(GLOBAL_STATE->sock, username);


### PR DESCRIPTION
Fixed mining.configure order as it should be sent first, per BIP0310