### PR TITLE
Fix formula for automatic fan control and adjust minimum fan speed

### DIFF
--- a/main/tasks/power_management_task.c
+++ b/main/tasks/power_management_task.c
@@ -144,11 +144,11 @@ void POWER_MANAGEMENT_task(void * pvParameters)
 }
 
 // Set the fan speed between 33% min and 100% max based on chip temperature as input.
-// The fan speed increases from 33% to 100% proportionally to the temperature increase from 40 and THROTTLE_TEMP
+// The fan speed increases from 33% to 100% proportionally to the temperature increase from 50 and THROTTLE_TEMP
 static void automatic_fan_speed(float chip_temp)
 {
     double result = 0.0;
-    double min_temp = 40.0;
+    double min_temp = 50.0;
     double min_fan_speed = 33.0;
 
     if (chip_temp < min_temp) {

--- a/main/tasks/power_management_task.c
+++ b/main/tasks/power_management_task.c
@@ -161,4 +161,3 @@ static void automatic_fan_speed(float chip_temp)
 
     EMC2101_set_fan_speed((float) result / 100);
 }
-

--- a/main/tasks/power_management_task.c
+++ b/main/tasks/power_management_task.c
@@ -143,20 +143,22 @@ void POWER_MANAGEMENT_task(void * pvParameters)
     }
 }
 
-// Fan speed between 33 min and 100 max based on input,
-// proportional to temp increase between 50 and THROTTLE_TEMP
+// Set the fan speed between 33% min and 100% max based on chip temperature as input.
+// The fan speed increases from 33% to 100% proportionally to the temperature increase from 40 and THROTTLE_TEMP
 static void automatic_fan_speed(float chip_temp)
 {
     double result = 0.0;
     double min_temp = 40.0;
+    double min_fan_speed = 33.0;
 
     if (chip_temp < min_temp) {
-        result = 33;
+        result = min_fan_speed;
     } else if (chip_temp >= THROTTLE_TEMP) {
         result = 100;
     } else {
-        double range = THROTTLE_TEMP - min_temp;
-        result = ((chip_temp - min_temp) / range) * 67 + 33;
+        double temp_range = THROTTLE_TEMP - min_temp;
+        double fan_range = 100 - min_fan_speed;
+        result = ((chip_temp - min_temp) / temp_range) * fan_range + min_fan_speed;
     }
 
     EMC2101_set_fan_speed((float) result / 100);

--- a/main/tasks/power_management_task.c
+++ b/main/tasks/power_management_task.c
@@ -143,7 +143,8 @@ void POWER_MANAGEMENT_task(void * pvParameters)
     }
 }
 
-// all values input below 60 result in 38 but increases exponentially such that an input of 70 results in 100
+// Fan speed between 25 min and 100 max based on input,
+// proportial to temp increase between 50 and THROTTLE_TEMP
 static void automatic_fan_speed(float chip_temp)
 {
     double result = 0.0;
@@ -155,7 +156,7 @@ static void automatic_fan_speed(float chip_temp)
         result = 100;
     } else {
         double range = THROTTLE_TEMP - min_temp;
-        result = ((chip_temp - min_temp) / range) * 100;
+        result = ((chip_temp - min_temp) / range) * 75 + 25;
     }
 
     EMC2101_set_fan_speed((float) result / 100);

--- a/main/tasks/power_management_task.c
+++ b/main/tasks/power_management_task.c
@@ -143,21 +143,22 @@ void POWER_MANAGEMENT_task(void * pvParameters)
     }
 }
 
-// Fan speed between 25 min and 100 max based on input,
-// proportial to temp increase between 50 and THROTTLE_TEMP
+// Fan speed between 33 min and 100 max based on input,
+// proportional to temp increase between 50 and THROTTLE_TEMP
 static void automatic_fan_speed(float chip_temp)
 {
     double result = 0.0;
-    double min_temp = 50.0;
+    double min_temp = 40.0;
 
     if (chip_temp < min_temp) {
-        result = 25;
+        result = 33;
     } else if (chip_temp >= THROTTLE_TEMP) {
         result = 100;
     } else {
         double range = THROTTLE_TEMP - min_temp;
-        result = ((chip_temp - min_temp) / range) * 75 + 25;
+        result = ((chip_temp - min_temp) / range) * 67 + 33;
     }
 
     EMC2101_set_fan_speed((float) result / 100);
 }
+

--- a/main/tasks/power_management_task.c
+++ b/main/tasks/power_management_task.c
@@ -143,13 +143,13 @@ void POWER_MANAGEMENT_task(void * pvParameters)
     }
 }
 
-// Set the fan speed between 33% min and 100% max based on chip temperature as input.
-// The fan speed increases from 33% to 100% proportionally to the temperature increase from 50 and THROTTLE_TEMP
+// Set the fan speed between 20% min and 100% max based on chip temperature as input.
+// The fan speed increases from 20% to 100% proportionally to the temperature increase from 50 and THROTTLE_TEMP
 static void automatic_fan_speed(float chip_temp)
 {
     double result = 0.0;
     double min_temp = 50.0;
-    double min_fan_speed = 33.0;
+    double min_fan_speed = 20.0;
 
     if (chip_temp < min_temp) {
         result = min_fan_speed;


### PR DESCRIPTION
Fixed the formula for the  automatic fan control #58.

Adjusted the minimum fan speed to 33 (vs 25 previously), and min temp to 40 degrees c (vs 50 previously), as tests with a Noctua NF-A4x10 5V PWM at 24 degree c ambient, show that this keeps the chip temperature cooler (~42 degrees c) than the previsous minimums (~51 degrees c).