### PR TITLE
Network resets2

### DIFF
--- a/main/system.c
+++ b/main/system.c
@@ -48,6 +48,12 @@ static void _init_system(GlobalState * global_state, SystemModule * module)
     module->lastClockSync = 0;
     module->FOUND_BLOCK = false;
     module->startup_done = false;
+    
+    // set the pool url
+    module->pool_url = nvs_config_get_string(NVS_CONFIG_STRATUM_URL, CONFIG_STRATUM_URL);
+
+    //set the pool port
+    module->pool_port = nvs_config_get_u16(NVS_CONFIG_STRATUM_PORT, CONFIG_STRATUM_PORT);
 
     // set the best diff string
     _suffix_string(module->best_nonce_diff, module->best_diff_string, DIFF_STRING_SIZE, 0);

--- a/main/system.h
+++ b/main/system.h
@@ -27,6 +27,8 @@ typedef struct
     bool startup_done;
     char ssid[20];
     char wifi_status[20];
+    char * pool_url;
+    uint16_t pool_port;
 
     uint32_t lastClockSync;
 } SystemModule;

--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -45,9 +45,6 @@ void stratum_task(void *pvParameters)
     int addr_family = 0;
     int ip_protocol = 0;
 
-    // char *stratum_url = nvs_config_get_string(NVS_CONFIG_STRATUM_URL, STRATUM_URL);
-    // uint16_t port = nvs_config_get_u16(NVS_CONFIG_STRATUM_PORT, PORT);
-
     char *stratum_url = GLOBAL_STATE->SYSTEM_MODULE.pool_url;
     uint16_t port = GLOBAL_STATE->SYSTEM_MODULE.pool_port;
 
@@ -58,8 +55,6 @@ void stratum_task(void *pvParameters)
     }
     else
     {
-        // it's a hostname. Lookup the ip address.
-        //IP_ADDR4(&ip_Addr, 0, 0, 0, 0);
         ESP_LOGI(TAG, "Get IP for URL: %s\n", stratum_url);
         dns_gethostbyname(stratum_url, &ip_Addr, dns_found_cb, NULL);
         while (!bDNSFound);
@@ -79,7 +74,6 @@ void stratum_task(void *pvParameters)
              ip4_addr3(&ip_Addr.u_addr.ip4),
              ip4_addr4(&ip_Addr.u_addr.ip4));
     ESP_LOGI(TAG, "Connecting to: stratum+tcp://%s:%d (%s)\n", stratum_url, port, host_ip);
-    //free(stratum_url);
 
     while (1)
     {


### PR DESCRIPTION
This change handles two Stratum URL error modes that used to cause us to get into a reboot loop;

- DNS lookup fails
- DNS lookup works, but connect() fails