### PR TITLE
Update power management (HAS_POWER_EN and HAS_PLUG_SENSE) to support board version 205

### DIFF
--- a/main/tasks/power_management_task.c
+++ b/main/tasks/power_management_task.c
@@ -44,8 +44,8 @@ void POWER_MANAGEMENT_task(void * pvParameters)
 
     char * board_version = nvs_config_get_string(NVS_CONFIG_BOARD_VERSION, "unknown");
     power_management->HAS_POWER_EN =
-        (strcmp(board_version, "202") == 1 || strcmp(board_version, "203") == 1 || strcmp(board_version, "204") == 1);
-    power_management->HAS_PLUG_SENSE = strcmp(board_version, "204") == 1;
+        (strcmp(board_version, "202") == 1 || strcmp(board_version, "203") == 1 || strcmp(board_version, "204") == 1 || strcmp(board_version, "205") == 1);
+    power_management->HAS_PLUG_SENSE = strcmp(board_version, "204") == 1 || strcmp(board_version, "205") == 1;
     free(board_version);
 
     int last_frequency_increase = 0;
@@ -71,6 +71,7 @@ void POWER_MANAGEMENT_task(void * pvParameters)
     } else {
         // turn ASIC off
         gpio_set_level(GPIO_NUM_10, 1);
+        ESP_LOGE(TAG, "No 5V power (barrel jack) available - ASIC disabled");
     }
 
     vTaskDelay(3000 / portTICK_PERIOD_MS);
@@ -148,9 +149,9 @@ void POWER_MANAGEMENT_task(void * pvParameters)
                 (power_management->frequency_value > 50 || power_management->voltage > 1000)) {
                 ESP_LOGE(TAG, "OVERHEAT");
 
-
                 if (power_management->HAS_POWER_EN) {
                     gpio_set_level(GPIO_NUM_10, 1);
+                    ESP_LOGE(TAG, "OVERHEAT detected - ASIC disabled");
                 } else {
                     nvs_config_set_u16(NVS_CONFIG_ASIC_VOLTAGE, 990);
                     nvs_config_set_u16(NVS_CONFIG_ASIC_FREQ, 50);
@@ -176,6 +177,7 @@ void POWER_MANAGEMENT_task(void * pvParameters)
             if (gpio12_state == 0) {
                 // turn ASIC off
                 gpio_set_level(GPIO_NUM_10, 1);
+                ESP_LOGE(TAG, "No 5V power (barrel jack) available - ASIC disabled");
             }
         }
 


### PR DESCRIPTION
I understood from the feedback in #148 HAS_PLUG_SENSE might not be needed anymore due to hardware changes. However as older boards w/o this hardware changes already exist, it might be (IMHO) needed to keep HAS_PLUG_SENSE for a while. This PR was made to update the current code to include board version 205.
I also included some minor logging improvements to indicate ASIC was switched off.