### PR TITLE
Replaced u_int64_t with uint64_t

### DIFF
--- a/components/bm1397/bm1397.c
+++ b/components/bm1397/bm1397.c
@@ -209,7 +209,7 @@ void BM1397_send_hash_frequency(float frequency)
     ESP_LOGI(TAG, "Setting Frequency to %.2fMHz (%.2f)", frequency, newf);
 }
 
-static void _send_init(u_int64_t frequency)
+static void _send_init(uint64_t frequency)
 {
 
     // send serial data
@@ -266,7 +266,7 @@ static void _send_read_address(void)
     _send_BM1397((TYPE_CMD | GROUP_ALL | CMD_READ), read_address, 2, false);
 }
 
-void BM1397_init(u_int64_t frequency)
+void BM1397_init(uint64_t frequency)
 {
     ESP_LOGI(TAG, "Initializing BM1397");
 

--- a/components/bm1397/include/bm1366.h
+++ b/components/bm1397/include/bm1366.h
@@ -7,11 +7,11 @@
 
 #define CRC5_MASK 0x1F
 
-// static const u_int64_t BM1366_FREQUENCY = CONFIG_ASIC_FREQUENCY;
-static const u_int64_t BM1366_CORE_COUNT = 672;
-// static const u_int64_t BM1366_HASHRATE_S = BM1366_FREQUENCY * BM1366_CORE_COUNT * 1000000;
+// static const uint64_t BM1366_FREQUENCY = CONFIG_ASIC_FREQUENCY;
+static const uint64_t BM1366_CORE_COUNT = 672;
+// static const uint64_t BM1366_HASHRATE_S = BM1366_FREQUENCY * BM1366_CORE_COUNT * 1000000;
 //  2^32
-//  static const u_int64_t NONCE_SPACE = 4294967296;
+//  static const uint64_t NONCE_SPACE = 4294967296;
 static const double BM1366_FULLSCAN_MS = 2140;
 
 typedef struct
@@ -31,7 +31,7 @@ typedef struct __attribute__((__packed__))
     uint8_t version[4];
 } BM1366_job;
 
-uint8_t BM1366_init(u_int64_t frequency);
+uint8_t BM1366_init(uint64_t frequency);
 
 void BM1366_send_init(void);
 void BM1366_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);

--- a/components/bm1397/include/bm1368.h
+++ b/components/bm1397/include/bm1368.h
@@ -7,11 +7,11 @@
 
 #define CRC5_MASK 0x1F
 
-// static const u_int64_t BM1368_FREQUENCY = CONFIG_ASIC_FREQUENCY;
-static const u_int64_t BM1368_CORE_COUNT = 672;
-// static const u_int64_t BM1368_HASHRATE_S = BM1368_FREQUENCY * BM1368_CORE_COUNT * 1000000;
+// static const uint64_t BM1368_FREQUENCY = CONFIG_ASIC_FREQUENCY;
+static const uint64_t BM1368_CORE_COUNT = 672;
+// static const uint64_t BM1368_HASHRATE_S = BM1368_FREQUENCY * BM1368_CORE_COUNT * 1000000;
 //  2^32
-//  static const u_int64_t NONCE_SPACE = 4294967296;
+//  static const uint64_t NONCE_SPACE = 4294967296;
 static const double BM1368_FULLSCAN_MS = 2140;
 
 typedef struct
@@ -31,7 +31,7 @@ typedef struct __attribute__((__packed__))
     uint8_t version[4];
 } BM1368_job;
 
-uint8_t BM1368_init(u_int64_t frequency);
+uint8_t BM1368_init(uint64_t frequency);
 
 uint8_t BM1368_send_init(void);
 void BM1368_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);

--- a/components/bm1397/include/bm1397.h
+++ b/components/bm1397/include/bm1397.h
@@ -7,11 +7,11 @@
 
 #define CRC5_MASK 0x1F
 
-// static const u_int64_t ASIC_FREQUENCY = CONFIG_ASIC_FREQUENCY;
-static const u_int64_t BM1397_CORE_COUNT = 672;
-// static const u_int64_t BM1397_HASHRATE_S = ASIC_FREQUENCY * BM1397_CORE_COUNT * 1000000;
+// static const uint64_t ASIC_FREQUENCY = CONFIG_ASIC_FREQUENCY;
+static const uint64_t BM1397_CORE_COUNT = 672;
+// static const uint64_t BM1397_HASHRATE_S = ASIC_FREQUENCY * BM1397_CORE_COUNT * 1000000;
 //  2^32
-static const u_int64_t NONCE_SPACE = 4294967296;
+static const uint64_t NONCE_SPACE = 4294967296;
 // static const double BM1397_FULLSCAN_MS = ((double) NONCE_SPACE / (double) BM1397_HASHRATE_S) * 1000;
 
 typedef struct
@@ -45,7 +45,7 @@ typedef struct __attribute__((__packed__))
     uint8_t midstate3[32];
 } job_packet;
 
-void BM1397_init(u_int64_t frequency);
+void BM1397_init(uint64_t frequency);
 
 void BM1397_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1397_set_job_difficulty_mask(int);

--- a/main/global_state.h
+++ b/main/global_state.h
@@ -16,7 +16,7 @@
 
 typedef struct
 {
-    uint8_t (*init_fn)(u_int64_t);
+    uint8_t (*init_fn)(uint64_t);
     task_result * (*receive_result_fn)(void * GLOBAL_STATE);
     int (*set_max_baud_fn)(void);
     void (*set_difficulty_mask_fn)(int);


### PR DESCRIPTION
A quick find on `u_int64_t` and replaced with `uint64_t`.