### PR TITLE
issue #100 resolved - ASIC not always starting/hashing after boot (due to race condition)

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -137,10 +137,10 @@ void app_main(void)
         SERIAL_init();
         (*GLOBAL_STATE.ASIC_functions.init_fn)(GLOBAL_STATE.POWER_MANAGEMENT_MODULE.frequency_value);
 
-        xTaskCreate(stratum_task, "stratum admin", 8192, (void *) &GLOBAL_STATE, 5, NULL);
-        xTaskCreate(create_jobs_task, "stratum miner", 8192, (void *) &GLOBAL_STATE, 10, NULL);
-        xTaskCreate(ASIC_task, "asic", 8192, (void *) &GLOBAL_STATE, 10, NULL);
         xTaskCreate(ASIC_result_task, "asic result", 8192, (void *) &GLOBAL_STATE, 15, NULL);
+        xTaskCreate(ASIC_task, "asic", 8192, (void *) &GLOBAL_STATE, 10, NULL);
+        xTaskCreate(create_jobs_task, "stratum miner", 8192, (void *) &GLOBAL_STATE, 10, NULL);
+        xTaskCreate(stratum_task, "stratum admin", 8192, (void *) &GLOBAL_STATE, 5, NULL);
     }
 }
 

--- a/main/main.c
+++ b/main/main.c
@@ -137,10 +137,10 @@ void app_main(void)
         SERIAL_init();
         (*GLOBAL_STATE.ASIC_functions.init_fn)(GLOBAL_STATE.POWER_MANAGEMENT_MODULE.frequency_value);
 
-        xTaskCreate(ASIC_result_task, "asic result", 8192, (void *) &GLOBAL_STATE, 15, NULL);
-        xTaskCreate(ASIC_task, "asic", 8192, (void *) &GLOBAL_STATE, 10, NULL);
-        xTaskCreate(create_jobs_task, "stratum miner", 8192, (void *) &GLOBAL_STATE, 10, NULL);
         xTaskCreate(stratum_task, "stratum admin", 8192, (void *) &GLOBAL_STATE, 5, NULL);
+        xTaskCreate(create_jobs_task, "stratum miner", 8192, (void *) &GLOBAL_STATE, 10, NULL);
+        xTaskCreate(ASIC_task, "asic", 8192, (void *) &GLOBAL_STATE, 10, NULL);
+        xTaskCreate(ASIC_result_task, "asic result", 8192, (void *) &GLOBAL_STATE, 15, NULL);
     }
 }
 

--- a/main/main.c
+++ b/main/main.c
@@ -136,6 +136,8 @@ void app_main(void)
 
         SERIAL_init();
         (*GLOBAL_STATE.ASIC_functions.init_fn)(GLOBAL_STATE.POWER_MANAGEMENT_MODULE.frequency_value);
+        SERIAL_set_baud((*GLOBAL_STATE.ASIC_functions.set_max_baud_fn)());
+        SERIAL_clear_buffer();
 
         xTaskCreate(stratum_task, "stratum admin", 8192, (void *) &GLOBAL_STATE, 5, NULL);
         xTaskCreate(create_jobs_task, "stratum miner", 8192, (void *) &GLOBAL_STATE, 10, NULL);

--- a/main/tasks/asic_result_task.c
+++ b/main/tasks/asic_result_task.c
@@ -12,7 +12,6 @@ const char *TAG = "asic_result";
 void ASIC_result_task(void *pvParameters)
 {
     GlobalState *GLOBAL_STATE = (GlobalState *)pvParameters;
-    SERIAL_clear_buffer();
 
     char *user = nvs_config_get_string(NVS_CONFIG_STRATUM_USER, STRATUM_USER);
 

--- a/main/tasks/asic_task.c
+++ b/main/tasks/asic_task.c
@@ -25,10 +25,6 @@ void ASIC_task(void *pvParameters)
         GLOBAL_STATE->valid_jobs[i] = 0;
     }
 
-    int baud = (*GLOBAL_STATE->ASIC_functions.set_max_baud_fn)();
-    vTaskDelay(10 / portTICK_PERIOD_MS);
-    SERIAL_set_baud(baud);
-
     SYSTEM_notify_mining_started(&GLOBAL_STATE->SYSTEM_MODULE);
     ESP_LOGI(TAG, "ASIC Ready!");
     while (1)


### PR DESCRIPTION
This PR should fix #100 by resolving a race condition during boot state. It seems the work tasks/queues were blocking each other.