### PR TITLE
fix Best Difficulty can not be > 4.29G

### DIFF
--- a/main/system.c
+++ b/main/system.c
@@ -56,7 +56,7 @@ static void _init_system(GlobalState * global_state, SystemModule * module)
     module->pool_port = nvs_config_get_u16(NVS_CONFIG_STRATUM_PORT, CONFIG_STRATUM_PORT);
 
     // set the best diff string
-    _suffix_string((uint64_t) module->best_nonce_diff, module->best_diff_string, DIFF_STRING_SIZE, 0);
+    _suffix_string(module->best_nonce_diff, module->best_diff_string, DIFF_STRING_SIZE, 0);
 
     // set the ssid string to blank
     memset(module->ssid, 0, 20);
@@ -269,12 +269,12 @@ static double _calculate_network_difficulty(uint32_t nBits)
 
 static void _check_for_best_diff(SystemModule * module, double diff, uint32_t nbits)
 {
-    if (diff <= module->best_nonce_diff) {
+    if ((uint64_t) diff <= module->best_nonce_diff) {
         return;
     }
-    module->best_nonce_diff = diff;
+    module->best_nonce_diff = (uint64_t) diff;
 
-    nvs_config_set_u64(NVS_CONFIG_BEST_DIFF, (uint64_t) module->best_nonce_diff);
+    nvs_config_set_u64(NVS_CONFIG_BEST_DIFF, module->best_nonce_diff);
 
     // make the best_nonce_diff into a string
     _suffix_string((uint64_t) diff, module->best_diff_string, DIFF_STRING_SIZE, 0);

--- a/main/system.c
+++ b/main/system.c
@@ -56,7 +56,7 @@ static void _init_system(GlobalState * global_state, SystemModule * module)
     module->pool_port = nvs_config_get_u16(NVS_CONFIG_STRATUM_PORT, CONFIG_STRATUM_PORT);
 
     // set the best diff string
-    _suffix_string(module->best_nonce_diff, module->best_diff_string, DIFF_STRING_SIZE, 0);
+    _suffix_string((uint64_t) module->best_nonce_diff, module->best_diff_string, DIFF_STRING_SIZE, 0);
 
     // set the ssid string to blank
     memset(module->ssid, 0, 20);
@@ -274,7 +274,7 @@ static void _check_for_best_diff(SystemModule * module, double diff, uint32_t nb
     }
     module->best_nonce_diff = diff;
 
-    nvs_config_set_u64(NVS_CONFIG_BEST_DIFF, module->best_nonce_diff);
+    nvs_config_set_u64(NVS_CONFIG_BEST_DIFF, (uint64_t) module->best_nonce_diff);
 
     // make the best_nonce_diff into a string
     _suffix_string((uint64_t) diff, module->best_diff_string, DIFF_STRING_SIZE, 0);

--- a/main/system.h
+++ b/main/system.h
@@ -21,7 +21,7 @@ typedef struct
     uint16_t shares_rejected;
     int screen_page;
     char oled_buf[20];
-    double best_nonce_diff;
+    uint64_t best_nonce_diff;
     char best_diff_string[DIFF_STRING_SIZE];
     bool FOUND_BLOCK;
     bool startup_done;

--- a/main/system.h
+++ b/main/system.h
@@ -21,7 +21,7 @@ typedef struct
     uint16_t shares_rejected;
     int screen_page;
     char oled_buf[20];
-    uint32_t best_nonce_diff;
+    double best_nonce_diff;
     char best_diff_string[DIFF_STRING_SIZE];
     bool FOUND_BLOCK;
     bool startup_done;


### PR DESCRIPTION
best_nonce_diff used to be defined as uint32_t (max value 4294967295). IMHO it should (at least) be defined as double otherwise Bitaxe UI might show a far too low 'Best Difficulty' value (can not be > 4.29G (uint32_t max value)).

I noticed this as public-pool is showing "Your Best Difficulty: 15.46G" but Bitaxe UI claims just "Best Difficulty: 4.29G"