### PR TITLE
TinyChipHub - Implement test driver for EMC2302

### DIFF
--- a/main/EMC2302.c
+++ b/main/EMC2302.c
@@ -41,7 +41,6 @@ static esp_err_t register_write_byte(uint8_t reg_addr, uint8_t data)
 // run this first. sets up the PWM polarity register
 void EMC2302_init(bool invertPolarity)
 {
-
     if (invertPolarity) {
         ESP_ERROR_CHECK(register_write_byte(EMC2302_PWM_POLARITY, 0b00011111));
     }
@@ -53,7 +52,7 @@ void EMC2302_set_fan_speed(uint8_t devicenum, float percent)
     uint8_t speed;
 	uint8_t FAN_SETTING_REG = EMC2302_FAN1_SETTING + (devicenum * 0x10);
 
-    speed = (uint8_t) (63.0 * percent);
+    speed = (uint8_t) (255.0 * percent);
     ESP_ERROR_CHECK(register_write_byte(FAN_SETTING_REG, speed));
 }
 
@@ -70,6 +69,7 @@ uint16_t EMC2302_get_fan_speed(uint8_t devicenum)
 
     ESP_LOGI(TAG, "Raw Fan Speed[%d] = %02X %02X", devicenum, tach_msb, tach_lsb);
     RPM = (tach_msb << 5) + ((tach_lsb >> 3) & 0x1F);
+    RPM = EMC2302_FAN_RPM_NUMERATOR / RPM;
     ESP_LOGI(TAG, "Fan Speed[%d] = %d RPM", devicenum, RPM);
 
     return RPM;

--- a/main/EMC2302.h
+++ b/main/EMC2302.h
@@ -2,7 +2,8 @@
 #define EMC2302_H_
 
 
-#define EMC2302_I2CADDR_DEFAULT 0x2F ///< EMC2302 default i2c address
+#define EMC2302_I2CADDR_DEFAULT 0x2F ///< EMC2302-2 default i2c address
+#define EMC2302_1_I2CADDR_DEFAULT 0x2E ///< EMC2302-2 default i2c address
 #define EMC2302_WHOAMI 0xFD          ///< Chip ID register
 #define EMC2302_MANUFACTURER_ID 0xFE ///< Manufacturer ID
 #define EMC2302_REVISION 0xFF        ///< Chip revision
@@ -50,7 +51,7 @@
 #define EMC2302_TACH2_LSB 0x4E          ///< Tach 2 reading low byte
 #define EMC2302_TACH2_MSB 0x4F          ///< Tach 2 reading high byte
 
-#define EMC2302_FAN_RPM_NUMERATOR 5400000 ///< Conversion unit to convert LSBs to fan RPM
+#define EMC2302_FAN_RPM_NUMERATOR 3932160 ///< Conversion unit to convert LSBs to fan RPM
 #define _TEMP_LSB 0.125                   ///< single bit value for internal temperature readings
 
 /**

--- a/main/TPS546.h
+++ b/main/TPS546.h
@@ -41,8 +41,9 @@
 #define TPS546_INIT_IOUT_OC_FAULT_RESPONSE 0xC0  /* shut down, no retries */
 
   /* temperature */
-#define TPS546_INIT_OT_WARN_LIMIT  70 /* degrees C */
-#define TPS546_INIT_OT_FAULT_LIMIT 80 /* degrees C */
+// It is better to set the temperature warn limit for TPS546 more higher than Ultra 
+#define TPS546_INIT_OT_WARN_LIMIT  105 /* degrees C */
+#define TPS546_INIT_OT_FAULT_LIMIT 145 /* degrees C */
 #define TPS546_INIT_OT_FAULT_RESPONSE 0xFF /* wait for cooling, and retry */
 
   /* timing */

--- a/main/tasks/power_management_task.c
+++ b/main/tasks/power_management_task.c
@@ -58,6 +58,26 @@ static void automatic_fan_speed(float chip_temp)
     EMC2101_set_fan_speed((float) result / 100);
 }
 
+static void automatic_fan_speed_hex(float chip_temp)
+{
+    double result = 0.0;
+    double min_temp = 50.0;
+    double min_fan_speed = 20.0;
+
+    if (chip_temp < min_temp) {
+        result = min_fan_speed;
+    } else if (chip_temp >= THROTTLE_TEMP) {
+        result = 100;
+    } else {
+        double temp_range = THROTTLE_TEMP - min_temp;
+        double fan_range = 100 - min_fan_speed;
+        result = ((chip_temp - min_temp) / temp_range) * fan_range + min_fan_speed;
+    }
+
+    EMC2302_set_fan_speed(0,(float) result / 100);
+    EMC2302_set_fan_speed(1,(float) result / 100);
+}
+
 // Returns the vcore voltage using the appropriate source
 uint16_t Get_vcore(void)
 {

--- a/main/tasks/power_management_task.h
+++ b/main/tasks/power_management_task.h
@@ -15,6 +15,7 @@ typedef struct
 } PowerManagementModule;
 
 static void automatic_fan_speed(float chip_temp);
+static void automatic_fan_speed_hex(float chip_temp);
 
 uint16_t Get_vcore(void);
 void POWER_MANAGEMENT_task(void * pvParameters);


### PR DESCRIPTION
Adding auto fan speed support for Hex board. Also change TPS546.h to increase `TPS546_INIT_OT_WARN_LIMIT` and `TPS546_INIT_OT_FAULT_LIMIT`