### PR TITLE
fix stratum parsing not always counting rejected shares

### DIFF
--- a/components/stratum/stratum_api.c
+++ b/components/stratum/stratum_api.c
@@ -118,25 +118,32 @@ void STRATUM_V1_parse(StratumApiV1Message * message, const char * stratum_json)
             result = MINING_SET_DIFFICULTY;
         } else if (strcmp("mining.set_version_mask", method_json->valuestring) == 0) {
             result = MINING_SET_VERSION_MASK;
+        } else {
+            ESP_LOGI(TAG, "unhandled method in stratum message: %s", stratum_json);
         }
     } else {
         // parse results
         cJSON * result_json = cJSON_GetObjectItem(json, "result");
-        if (result_json == NULL){
+        cJSON * error_json = cJSON_GetObjectItem(json, "error");
+        if (result_json == NULL) {
             message->response_success = false;
-        }
-        else if (cJSON_IsBool(result_json)) {
-            result = STRATUM_RESULT;
-            if (cJSON_IsTrue(result_json)) {
-                message->response_success = true;
-            }else{
-                message->response_success = false;
-            }
         } else {
             cJSON * mask = cJSON_GetObjectItem(result_json, "version-rolling.mask");
             if (mask != NULL) {
                 result = STRATUM_RESULT_VERSION_MASK;
                 message->version_mask = strtoul(mask->valuestring, NULL, 16);
+            } else if (cJSON_IsBool(result_json)) {
+                result = STRATUM_RESULT;
+                if (cJSON_IsTrue(result_json)) {
+                    message->response_success = true;
+                } else {
+                    message->response_success = false;
+                }
+            } else if (!cJSON_IsNull(error_json)) {
+                result = STRATUM_RESULT;
+                message->response_success = false;
+            } else {
+                ESP_LOGI(TAG, "unhandled result in stratum message: %s", stratum_json);
             }
         }
     }

--- a/components/stratum/test/test_stratum_json.c
+++ b/components/stratum/test/test_stratum_json.c
@@ -104,3 +104,33 @@ TEST_CASE("Parse stratum notify params", "[mining.notify]")
 //     TEST_ASSERT_EQUAL_STRING(extranonce, "e9695791");
 //     TEST_ASSERT_EQUAL_INT(extranonce2_len, 4);
 // }
+
+TEST_CASE("Parse stratum mining.set_version_mask params", "[stratum]")
+{
+    StratumApiV1Message stratum_api_v1_message = {};
+    const char *json_string = "{\"id\":1,\"method\":\"mining.set_version_mask\",\"params\":[\"1fffe000\"]}";
+    STRATUM_V1_parse(&stratum_api_v1_message, json_string);
+    TEST_ASSERT_EQUAL(1, stratum_api_v1_message.message_id);
+    TEST_ASSERT_EQUAL(MINING_SET_VERSION_MASK, stratum_api_v1_message.method);
+    TEST_ASSERT_EQUAL_HEX32(0x1fffe000, stratum_api_v1_message.version_mask);
+}
+
+TEST_CASE("Parse stratum result success", "[stratum]")
+{
+    StratumApiV1Message stratum_api_v1_message = {};
+    const char *json_string = "{\"id\":1,\"error\":null,\"result\":true}";
+    STRATUM_V1_parse(&stratum_api_v1_message, json_string);
+    TEST_ASSERT_EQUAL(1, stratum_api_v1_message.message_id);
+    TEST_ASSERT_EQUAL(STRATUM_RESULT, stratum_api_v1_message.method);
+    TEST_ASSERT_TRUE(stratum_api_v1_message.response_success);
+}
+
+TEST_CASE("Parse stratum result error", "[stratum]")
+{
+    StratumApiV1Message stratum_api_v1_message = {};
+    const char *json_string = "{\"id\":1,\"result\":null,\"error\":[21,\"Job not found\",\"\"]}";
+    STRATUM_V1_parse(&stratum_api_v1_message, json_string);
+    TEST_ASSERT_EQUAL(1, stratum_api_v1_message.message_id);
+    TEST_ASSERT_EQUAL(STRATUM_RESULT, stratum_api_v1_message.method);
+    TEST_ASSERT_FALSE(stratum_api_v1_message.response_success);
+}

--- a/main/tasks/asic_result_task.c
+++ b/main/tasks/asic_result_task.c
@@ -31,6 +31,7 @@ void ASIC_result_task(void *pvParameters)
         if (GLOBAL_STATE->valid_jobs[job_id] == 0)
         {
             ESP_LOGI(TAG, "Invalid job nonce found, id=%d", job_id);
+            continue;
         }
 
         // check the nonce difficulty


### PR DESCRIPTION
I noticed that IMHO the code was not always counting rejected shares correctly; at least when using public-pool.io.
The UI was always reporting 0 rejected shares even when shares got rejected (as per the log)

I noticed public-pool is responding to an accepted share with something like: 
`{"id":803,"error":null,"result":true}`

and a response to a rejected share is something like: 
`{"id":873,"result":null,"error":[21,"Job not found",""]}`

Reading the code, it seems it was expected to get "result":false in case of rejected shares. However as per https://braiins.com/stratum-v1/docs is seems be normal for the protocol to response with "result":null instead of "result":false for an error.

This PR change the code to simply increase the counter of rejected shares whenever the value of "error:" is not null. It also add some logging for some unhandled stratum messages (like unhandled methods and result parsing).

In order to not confuse users with high numbers of rejected shares it might be a good idea to show just "x percent rejected" instead of the actual number.