### PR TITLE
refactor: deduplicate i2c parameters

### DIFF
--- a/main/DS4432U.c
+++ b/main/DS4432U.c
@@ -3,13 +3,7 @@
 #include "esp_log.h"
 #include "driver/i2c.h"
 
-#define I2C_MASTER_SCL_IO 48        /*!< GPIO number used for I2C master clock */
-#define I2C_MASTER_SDA_IO 47        /*!< GPIO number used for I2C master data  */
-#define I2C_MASTER_NUM 0            /*!< I2C master i2c port number, the number of i2c peripheral interfaces available will depend on the chip */
-#define I2C_MASTER_FREQ_HZ 400000   /*!< I2C master clock frequency */
-#define I2C_MASTER_TX_BUF_DISABLE 0 /*!< I2C master doesn't need buffer */
-#define I2C_MASTER_RX_BUF_DISABLE 0 /*!< I2C master doesn't need buffer */
-#define I2C_MASTER_TIMEOUT_MS 1000
+#include "DS4432U.h"
 
 // DS4432U+ -- Adjustable current DAC for use with the TPS40305 voltage regulator
 // address: 0x90

--- a/main/DS4432U.h
+++ b/main/DS4432U.h
@@ -3,6 +3,8 @@
 
 #include "driver/i2c.h"
 
+#include "i2c_params.h"
+
 esp_err_t i2c_master_init(void);
 esp_err_t i2c_master_delete(void);
 void DS4432U_read(void);

--- a/main/EMC2101.c
+++ b/main/EMC2101.c
@@ -4,15 +4,6 @@
 
 #include "EMC2101.h"
 
-#define I2C_MASTER_SCL_IO 48 /*!< GPIO number used for I2C master clock */
-#define I2C_MASTER_SDA_IO 47 /*!< GPIO number used for I2C master data  */
-#define I2C_MASTER_NUM                                                                                                             \
-    0 /*!< I2C master i2c port number, the number of i2c peripheral interfaces available will depend on the chip */
-#define I2C_MASTER_FREQ_HZ 400000   /*!< I2C master clock frequency */
-#define I2C_MASTER_TX_BUF_DISABLE 0 /*!< I2C master doesn't need buffer */
-#define I2C_MASTER_RX_BUF_DISABLE 0 /*!< I2C master doesn't need buffer */
-#define I2C_MASTER_TIMEOUT_MS 1000
-
 // static const char *TAG = "EMC2101.c";
 
 /**

--- a/main/EMC2101.h
+++ b/main/EMC2101.h
@@ -1,6 +1,8 @@
 #ifndef EMC2101_H_
 #define EMC2101_H_
 
+#include "i2c_params.h"
+
 #define EMC2101_I2CADDR_DEFAULT 0x4C ///< EMC2101 default i2c address
 #define EMC2101_CHIP_ID 0x16         ///< EMC2101 default device id from part id
 #define EMC2101_ALT_CHIP_ID 0x28     ///< EMC2101 alternate device id from part id

--- a/main/INA260.c
+++ b/main/INA260.c
@@ -4,14 +4,6 @@
 
 #include "INA260.h"
 
-#define I2C_MASTER_SCL_IO 48        /*!< GPIO number used for I2C master clock */
-#define I2C_MASTER_SDA_IO 47        /*!< GPIO number used for I2C master data  */
-#define I2C_MASTER_NUM 0            /*!< I2C master i2c port number, the number of i2c peripheral interfaces available will depend on the chip */
-#define I2C_MASTER_FREQ_HZ 400000   /*!< I2C master clock frequency */
-#define I2C_MASTER_TX_BUF_DISABLE 0 /*!< I2C master doesn't need buffer */
-#define I2C_MASTER_RX_BUF_DISABLE 0 /*!< I2C master doesn't need buffer */
-#define I2C_MASTER_TIMEOUT_MS 1000
-
 // static const char *TAG = "INA260.c";
 
 /**

--- a/main/INA260.h
+++ b/main/INA260.h
@@ -1,6 +1,8 @@
 #ifndef INA260_H_
 #define INA260_H_
 
+#include "i2c_params.h"
+
 #define INA260_I2CADDR_DEFAULT 0x40 ///< INA260 default i2c address
 #define INA260_REG_CONFIG 0x00      ///< Configuration register
 #define INA260_REG_CURRENT 0x01     ///< Current measurement register (signed) in mA

--- a/main/i2c_params.h
+++ b/main/i2c_params.h
@@ -1,0 +1,12 @@
+#ifndef I2C_PARAMS_H_
+#define I2C_PARAMS_H_
+
+#define I2C_MASTER_SCL_IO 48        /*!< GPIO number used for I2C master clock */
+#define I2C_MASTER_SDA_IO 47        /*!< GPIO number used for I2C master data  */
+#define I2C_MASTER_NUM 0            /*!< I2C master i2c port number, the number of i2c peripheral interfaces available will depend on the chip */
+#define I2C_MASTER_FREQ_HZ 400000   /*!< I2C master clock frequency */
+#define I2C_MASTER_TX_BUF_DISABLE 0 /*!< I2C master doesn't need buffer */
+#define I2C_MASTER_RX_BUF_DISABLE 0 /*!< I2C master doesn't need buffer */
+#define I2C_MASTER_TIMEOUT_MS 1000
+
+#endif /* I2C_PARAMS_H_ */


### PR DESCRIPTION
DS4432U, EMC2101, and INA2101 all contain the same macros for I2C bus usage.
This PR deduplicates code by pulling these i2c macros into a common header.

```c
#define I2C_MASTER_SCL_IO 48        /*!< GPIO number used for I2C master clock */
#define I2C_MASTER_SDA_IO 47        /*!< GPIO number used for I2C master data  */
#define I2C_MASTER_NUM 0            /*!< I2C master i2c port number, the number of i2c peripheral interfaces available will depend on the chip */
#define I2C_MASTER_FREQ_HZ 400000   /*!< I2C master clock frequency */
#define I2C_MASTER_TX_BUF_DISABLE 0 /*!< I2C master doesn't need buffer */
#define I2C_MASTER_RX_BUF_DISABLE 0 /*!< I2C master doesn't need buffer */
#define I2C_MASTER_TIMEOUT_MS 1000
```

Also, since `DS4432U.c` was being touched, opportunistically added missing include for `DS4432U.h`.