### PR TITLE
Add software version string to the stratum mining.subscribe

### DIFF
--- a/components/stratum/CMakeLists.txt
+++ b/components/stratum/CMakeLists.txt
@@ -9,4 +9,5 @@ INCLUDE_DIRS
 REQUIRES 
     json
     mbedtls
+    app_update
 )

--- a/components/stratum/stratum_api.c
+++ b/components/stratum/stratum_api.c
@@ -7,6 +7,7 @@
 #include "stratum_api.h"
 #include "cJSON.h"
 #include "esp_log.h"
+#include "esp_ota_ops.h"
 #include "lwip/sockets.h"
 #include "utils.h"
 #include <stdio.h>
@@ -299,7 +300,9 @@ int STRATUM_V1_subscribe(int socket, char * model)
 {
     // Subscribe
     char subscribe_msg[BUFFER_SIZE];
-    sprintf(subscribe_msg, "{\"id\": %d, \"method\": \"mining.subscribe\", \"params\": [\"bitaxe/%s\"]}\n", send_uid++, model);
+    const esp_app_desc_t *app_desc = esp_ota_get_app_description();
+    const char *version = app_desc->version;	
+    sprintf(subscribe_msg, "{\"id\": %d, \"method\": \"mining.subscribe\", \"params\": [\"bitaxe/%s (%s)\"]}\n", send_uid++, model, version);
     debug_stratum_tx(subscribe_msg);
     write(socket, subscribe_msg, strlen(subscribe_msg));
 


### PR DESCRIPTION
Very minor mod to give pools greater visibility into what's running on the hardware by providing the software version string as part of the stratum mining.subscribe.  Many other mining hardware/software combos already provide this type of information to the pool.

This can potentially allow a pool to implement future device+version specific workarounds/tweaks as needed (and possible) on the pool side, as well as more detailed stats on which versions and hardware are operating if they decide to do so.