### PR TITLE
Small optimization : avoid strcmp

### DIFF
--- a/main/global_state.h
+++ b/main/global_state.h
@@ -14,6 +14,20 @@
 
 #define STRATUM_USER CONFIG_STRATUM_USER
 
+typedef enum
+{
+    DEVICE_MAX = 0,
+    DEVICE_ULTRA = 1,
+    DEVICE_SUPRA = 2,
+} DeviceModel;
+
+typedef enum
+{
+    ASIC_BM1397 = 0,
+    ASIC_BM1366 = 1,
+    ASIC_BM1368 = 2,
+} AsicModel;
+
 typedef struct
 {
     uint8_t (*init_fn)(uint64_t);
@@ -25,7 +39,10 @@ typedef struct
 
 typedef struct
 {
-    char * asic_model;
+    DeviceModel device_model;
+    char * device_model_str;
+    AsicModel asic_model;
+    char * asic_model_str;
     AsicFunctions ASIC_functions;
     double asic_job_frequency_ms;
     uint32_t initial_ASIC_difficulty;

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -376,7 +376,7 @@ static esp_err_t GET_system_info(httpd_req_t * req)
     cJSON_AddNumberToObject(root, "sharesAccepted", GLOBAL_STATE->SYSTEM_MODULE.shares_accepted);
     cJSON_AddNumberToObject(root, "sharesRejected", GLOBAL_STATE->SYSTEM_MODULE.shares_rejected);
     cJSON_AddNumberToObject(root, "uptimeSeconds", (esp_timer_get_time() - GLOBAL_STATE->SYSTEM_MODULE.start_time) / 1000000);
-    cJSON_AddStringToObject(root, "ASICModel", GLOBAL_STATE->asic_model);
+    cJSON_AddStringToObject(root, "ASICModel", GLOBAL_STATE->asic_model_str);
     cJSON_AddStringToObject(root, "stratumURL", stratumURL);
     cJSON_AddNumberToObject(root, "stratumPort", nvs_config_get_u16(NVS_CONFIG_STRATUM_PORT, CONFIG_STRATUM_PORT));
     cJSON_AddStringToObject(root, "stratumUser", stratumUser);

--- a/main/main.c
+++ b/main/main.c
@@ -28,9 +28,25 @@ void app_main(void)
     ESP_LOGI(TAG, "NVS_CONFIG_ASIC_FREQ %f", (float) nvs_config_get_u16(NVS_CONFIG_ASIC_FREQ, CONFIG_ASIC_FREQUENCY));
     GLOBAL_STATE.POWER_MANAGEMENT_MODULE.frequency_value = nvs_config_get_u16(NVS_CONFIG_ASIC_FREQ, CONFIG_ASIC_FREQUENCY);
 
-    GLOBAL_STATE.asic_model = nvs_config_get_string(NVS_CONFIG_ASIC_MODEL, "");
-    if (strcmp(GLOBAL_STATE.asic_model, "BM1366") == 0) {
+    GLOBAL_STATE.device_model_str = nvs_config_get_string(NVS_CONFIG_DEVICE_MODEL, "");
+    if (strcmp(GLOBAL_STATE.device_model_str, "max") == 0) {
+        ESP_LOGI(TAG, "DEVICE: Max");
+        GLOBAL_STATE.device_model = DEVICE_MAX;
+    } else if (strcmp(GLOBAL_STATE.device_model_str, "ultra") == 0) {
+        ESP_LOGI(TAG, "DEVICE: Ultra");
+        GLOBAL_STATE.device_model = DEVICE_ULTRA;
+    } else if (strcmp(GLOBAL_STATE.device_model_str, "supra") == 0) {
+        ESP_LOGI(TAG, "DEVICE: Supra");
+        GLOBAL_STATE.device_model = DEVICE_SUPRA;
+    } else {
+        ESP_LOGE(TAG, "Invalid DEVICE model");
+        // maybe should return here to now execute anything with a faulty device parameter !
+    }
+
+    GLOBAL_STATE.asic_model_str = nvs_config_get_string(NVS_CONFIG_ASIC_MODEL, "");
+    if (strcmp(GLOBAL_STATE.asic_model_str, "BM1366") == 0) {
         ESP_LOGI(TAG, "ASIC: BM1366");
+        GLOBAL_STATE.asic_model = ASIC_BM1366;
         AsicFunctions ASIC_functions = {.init_fn = BM1366_init,
                                         .receive_result_fn = BM1366_proccess_work,
                                         .set_max_baud_fn = BM1366_set_max_baud,
@@ -40,8 +56,9 @@ void app_main(void)
         GLOBAL_STATE.initial_ASIC_difficulty = BM1366_INITIAL_DIFFICULTY;
 
         GLOBAL_STATE.ASIC_functions = ASIC_functions;
-    } else if (strcmp(GLOBAL_STATE.asic_model, "BM1368") == 0) {
+    } else if (strcmp(GLOBAL_STATE.asic_model_str, "BM1368") == 0) {
         ESP_LOGI(TAG, "ASIC: BM1368");
+        GLOBAL_STATE.asic_model = ASIC_BM1368;
         AsicFunctions ASIC_functions = {.init_fn = BM1368_init,
                                         .receive_result_fn = BM1368_proccess_work,
                                         .set_max_baud_fn = BM1368_set_max_baud,
@@ -53,8 +70,9 @@ void app_main(void)
         GLOBAL_STATE.initial_ASIC_difficulty = BM1368_INITIAL_DIFFICULTY;
 
         GLOBAL_STATE.ASIC_functions = ASIC_functions;
-    } else if (strcmp(GLOBAL_STATE.asic_model, "BM1397") == 0) {
+    } else if (strcmp(GLOBAL_STATE.asic_model_str, "BM1397") == 0) {
         ESP_LOGI(TAG, "ASIC: BM1397");
+        GLOBAL_STATE.asic_model = ASIC_BM1397;
         AsicFunctions ASIC_functions = {.init_fn = BM1397_init,
                                         .receive_result_fn = BM1397_proccess_work,
                                         .set_max_baud_fn = BM1397_set_max_baud,
@@ -67,16 +85,17 @@ void app_main(void)
 
         GLOBAL_STATE.ASIC_functions = ASIC_functions;
     } else {
-        ESP_LOGI(TAG, "Invalid ASIC model");
+        ESP_LOGE(TAG, "Invalid ASIC model");
         AsicFunctions ASIC_functions = {.init_fn = NULL,
                                         .receive_result_fn = NULL,
                                         .set_max_baud_fn = NULL,
                                         .set_difficulty_mask_fn = NULL,
                                         .send_work_fn = NULL};
         GLOBAL_STATE.ASIC_functions = ASIC_functions;
+        // maybe should return here to now execute anything with a faulty device parameter !
     }
 
-    bool is_max = strcmp(GLOBAL_STATE.asic_model, "BM1397") == 0;
+    bool is_max = GLOBAL_STATE.asic_model == ASIC_BM1397;
     uint64_t best_diff = nvs_config_get_u64(NVS_CONFIG_BEST_DIFF, 0);
     uint16_t should_self_test = nvs_config_get_u16(NVS_CONFIG_SELF_TEST, 0);
     if (should_self_test == 1 && !is_max && best_diff < 1) {

--- a/main/tasks/power_management_task.c
+++ b/main/tasks/power_management_task.c
@@ -84,7 +84,7 @@ void POWER_MANAGEMENT_task(void * pvParameters)
         }
         power_management->fan_speed = EMC2101_get_fan_speed();
 
-        if (strcmp(GLOBAL_STATE->asic_model, "BM1397") == 0) {
+        if (GLOBAL_STATE->asic_model == ASIC_BM1397) {
 
             power_management->chip_temp = EMC2101_get_external_temp();
 
@@ -144,7 +144,7 @@ void POWER_MANAGEMENT_task(void * pvParameters)
                     last_frequency_increase++;
                 }
             }
-        } else if (strcmp(GLOBAL_STATE->asic_model, "BM1366") == 0 || strcmp(GLOBAL_STATE->asic_model, "BM1368") == 0) {
+        } else if (GLOBAL_STATE->asic_model == ASIC_BM1366 || GLOBAL_STATE->asic_model == ASIC_BM1368) {
             power_management->chip_temp = EMC2101_get_internal_temp() + 5;
 
             if (power_management->chip_temp > THROTTLE_TEMP &&

--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -103,7 +103,7 @@ void stratum_task(void * pvParameters)
 
         ///// Start Stratum Action
         // mining.subscribe - ID: 1
-        STRATUM_V1_subscribe(GLOBAL_STATE->sock, GLOBAL_STATE->asic_model);
+        STRATUM_V1_subscribe(GLOBAL_STATE->sock, GLOBAL_STATE->asic_model_str);
 
         // mining.configure - ID: 2
         STRATUM_V1_configure_version_rolling(GLOBAL_STATE->sock, &GLOBAL_STATE->version_mask);


### PR DESCRIPTION
There is no functional change in thsi PR, only a small optim : avoid strcmp.

This also permit to have board (device_model) dependant code (in preparation for BitaxeHex and other multi-chip boards).