### PR TITLE
Add quick link to stats when mining on OCEAN

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -154,6 +154,9 @@ export class HomeComponent {
         if (info.stratumURL.includes('public-pool.io')) {
           const address = info.stratumUser.split('.')[0]
           return `https://web.public-pool.io/#/app/${address}`;
+        } else if (info.stratumURL.includes('ocean.xyz')) {
+          const address = info.stratumUser.split('.')[0]
+          return `https://ocean.xyz/stats/${address}`;
         } else {
           return undefined;
         }


### PR DESCRIPTION
Following the lead of existing code, add a quick link to OCEAN stats in the UI when mining on an ocean.xyz host.

![image](https://github.com/skot/ESP-Miner/assets/1316379/2544b4fc-8cc9-45f0-bf1a-adbb1f9e039b)
