### PR TITLE
Update bm1397.c to increase the max frequency to 650Mhz

### DIFF
--- a/components/bm1397/bm1397.c
+++ b/components/bm1397/bm1397.c
@@ -132,7 +132,7 @@ void BM1397_send_hash_frequency(float frequency)
     float deffreq = 200.0;
 
     float fa, fb, fc1, fc2, newf;
-    float f1, basef, famax = 0xf0, famin = 0x10;
+    float f1, basef, famax = 0x104, famin = 0x10;
     int i;
 
     // bound the frequency setting
@@ -142,9 +142,9 @@ void BM1397_send_hash_frequency(float frequency)
     {
         f1 = 50;
     }
-    else if (frequency > 500)
+    else if (frequency > 650)
     {
-        f1 = 500;
+        f1 = 475;
     }
     else
     {
@@ -154,7 +154,7 @@ void BM1397_send_hash_frequency(float frequency)
     fb = 2;
     fc1 = 1;
     fc2 = 5; // initial multiplier of 10
-    if (f1 >= 500)
+    if (f1 > 650)
     {
         // halve down to '250-400'
         fb = 1;

--- a/components/bm1397/bm1397.c
+++ b/components/bm1397/bm1397.c
@@ -185,8 +185,8 @@ void BM1397_send_hash_frequency(float frequency)
     }
     else
     {
-        freqbuf[2] = 0x40 + (unsigned char)(fa >> 8);
-        freqbuf[3] = (unsigned char)(fa & 0xff);
+        freqbuf[2] = 0x40 + (unsigned char)((int)fa >> 8);
+        freqbuf[3] = (unsigned char)((int)fa & 0xff);
         freqbuf[4] = (unsigned char)fb;
         // fc1, fc2 'should' already be 1..15
         freqbuf[5] = (((unsigned char)fc1 & 0x7) << 4) + ((unsigned char)fc2 & 0x7);

--- a/components/bm1397/bm1397.c
+++ b/components/bm1397/bm1397.c
@@ -185,12 +185,12 @@ void BM1397_send_hash_frequency(float frequency)
     }
     else
     {
-        freqbuf[2] = 0x40 + (char)(fa >> 8);
-        freqbuf[3] = (int)fa;
-        freqbuf[4] = (int)fb;
+        freqbuf[2] = 0x40 + (unsigned char)(fa >> 8);
+        freqbuf[3] = (unsigned char)(fa & 0xff);
+        freqbuf[4] = (unsigned char)fb;
         // fc1, fc2 'should' already be 1..15
-        freqbuf[5] = (((int)fc1 & 0xf) << 4) + ((int)fc2 & 0xf);
-
+        freqbuf[5] = (((unsigned char)fc1 & 0x7) << 4) + ((unsigned char)fc2 & 0x7);
+        
         newf = basef / ((float)fb * (float)fc1 * (float)fc2);
     }
 

--- a/components/bm1397/bm1397.c
+++ b/components/bm1397/bm1397.c
@@ -144,7 +144,7 @@ void BM1397_send_hash_frequency(float frequency)
     }
     else if (frequency > 650)
     {
-        f1 = 475;
+        f1 = 650;
     }
     else
     {

--- a/components/bm1397/bm1397.c
+++ b/components/bm1397/bm1397.c
@@ -154,7 +154,7 @@ void BM1397_send_hash_frequency(float frequency)
     fb = 2;
     fc1 = 1;
     fc2 = 5; // initial multiplier of 10
-    if (f1 > 650)
+    if (f1 >= 500)
     {
         // halve down to '250-400'
         fb = 1;

--- a/components/bm1397/bm1397.c
+++ b/components/bm1397/bm1397.c
@@ -171,7 +171,7 @@ void BM1397_send_hash_frequency(float frequency)
     }
     // else f1 is 250-500
 
-    // f1 * fb * fc1 * fc2 is between 2500 and 5000
+    // f1 * fb * fc1 * fc2 is between 2500 and 6500
     // - so round up to the next 25 (freq_mult)
     basef = FREQ_MULT * ceil(f1 * fb * fc1 * fc2 / FREQ_MULT);
 
@@ -185,6 +185,7 @@ void BM1397_send_hash_frequency(float frequency)
     }
     else
     {
+        freqbuf[2] = 0x40 + (char)(fa >> 8);
         freqbuf[3] = (int)fa;
         freqbuf[4] = (int)fb;
         // fc1, fc2 'should' already be 1..15

--- a/main/http_server/axe-os/src/app/components/edit/edit.component.ts
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.ts
@@ -36,6 +36,13 @@ export class EditComponent implements OnInit {
     { name: '525', value: 525 },
     { name: '550', value: 550 },
     { name: '575', value: 575 },
+    { name: '590', value: 590 },
+    { name: '600', value: 600 },
+    { name: '610', value: 610 },
+    { name: '620', value: 620 },
+    { name: '630', value: 630 },
+    { name: '640', value: 640 },
+    { name: '650', value: 650 },
   ];
 
   public BM1366DropdownFrequency = [

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
 [![](https://dcbadge.vercel.app/api/server/3E8ca2dkcC)](https://discord.gg/3E8ca2dkcC)
 
 # ESP-Miner
+# Forked from v2.1.6
 
 | Supported Targets | ESP32-S3 (BitAxe v2+) |
 | ----------------- | --------------------- |

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,6 @@
 [![](https://dcbadge.vercel.app/api/server/3E8ca2dkcC)](https://discord.gg/3E8ca2dkcC)
 
 # ESP-Miner
-# Forked from v2.1.6
 
 | Supported Targets | ESP32-S3 (BitAxe v2+) |
 | ----------------- | --------------------- |


### PR DESCRIPTION
The original version was setting everything above 500Mhz to 500Mhz, the update increases the limit to 650Mhz. Added changes to the web interface also.