### PR TITLE
fix: check www.bin size before flashing

### DIFF
--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -431,6 +431,12 @@ esp_err_t POST_WWW_update(httpd_req_t * req)
         return ESP_FAIL;
     }
 
+    // Don't attempt to write more than what can be stored in the partition
+    if (remaining > www_partition->size) {
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "File provided is too large for device");
+        return ESP_FAIL;
+    }
+
     // Erase the entire www partition before writing
     ESP_ERROR_CHECK(esp_partition_erase_range(www_partition, 0, www_partition->size));
 


### PR DESCRIPTION
Adds a basic sanity/safety check for www.bin uploading.
Returns 400 if upload is attempted on a file larger than the available partition space.
Tested with:
```
mv www.bin www.bin.original
cat www.bin.original www.bin.original > www.bin
```
and attempting a website upload in Settings of `www.bin`.

Notes: 
 - Confirmed in browser (Chrome) developer tools / network that 400 is returned.  On my browser, the UI doesn't show the 400 (which may be a different issue, although happy to integrate into this PR if appropriate).
 - For now, `HTTPD_400_BAD_REQUEST` is being used.  The master branch of esp-idf has `HTTPD_413_CONTENT_TOO_LARGE` (which seems like a more appropriate status code than 400), so when it becomes available in a release (e.g. 5.4), we can switch to 413.

https://github.com/espressif/esp-idf/commit/e40b1402e44d512120e12e7ff97194adf5827a86