### PR TITLE
Change stratum message_id to int64_t

### DIFF
--- a/components/stratum/include/stratum_api.h
+++ b/components/stratum/include/stratum_api.h
@@ -45,7 +45,7 @@ typedef struct
     char * extranonce_str;
     int extranonce_2_len;
 
-    int16_t message_id;
+    int64_t message_id;
     // Indicates the type of request the message represents.
     stratum_method method;
 

--- a/components/stratum/stratum_api.c
+++ b/components/stratum/stratum_api.c
@@ -111,7 +111,7 @@ void STRATUM_V1_parse(StratumApiV1Message * message, const char * stratum_json)
     cJSON * json = cJSON_Parse(stratum_json);
 
     cJSON * id_json = cJSON_GetObjectItem(json, "id");
-    int16_t parsed_id = -1;
+    int64_t parsed_id = -1;
     if (id_json != NULL && cJSON_IsNumber(id_json)) {
         parsed_id = id_json->valueint;
     }

--- a/components/stratum/test/test_stratum_json.c
+++ b/components/stratum/test/test_stratum_json.c
@@ -125,6 +125,26 @@ TEST_CASE("Parse stratum result success", "[stratum]")
     TEST_ASSERT_TRUE(stratum_api_v1_message.response_success);
 }
 
+TEST_CASE("Parse stratum result success with large id", "[stratum]")
+{
+    StratumApiV1Message stratum_api_v1_message = {};
+    const char *json_string = "{\"id\":32769,\"error\":null,\"result\":true}";
+    STRATUM_V1_parse(&stratum_api_v1_message, json_string);
+    TEST_ASSERT_EQUAL(32768, stratum_api_v1_message.message_id);
+    TEST_ASSERT_EQUAL(STRATUM_RESULT, stratum_api_v1_message.method);
+    TEST_ASSERT_TRUE(stratum_api_v1_message.response_success);
+}
+
+TEST_CASE("Parse stratum result success with larger id", "[stratum]")
+{
+    StratumApiV1Message stratum_api_v1_message = {};
+    const char *json_string = "{\"id\":65536,\"error\":null,\"result\":true}";
+    STRATUM_V1_parse(&stratum_api_v1_message, json_string);
+    TEST_ASSERT_EQUAL(65536, stratum_api_v1_message.message_id);
+    TEST_ASSERT_EQUAL(STRATUM_RESULT, stratum_api_v1_message.method);
+    TEST_ASSERT_TRUE(stratum_api_v1_message.response_success);
+}
+
 TEST_CASE("Parse stratum result error", "[stratum]")
 {
     StratumApiV1Message stratum_api_v1_message = {};


### PR DESCRIPTION
The message_id from the stratum result message wraps around at 32k. This should fix #219.

One of the added tests should fail on purpose, but I doubt they will run on the GitHub build.