### PR TITLE
Fix #245 (BM1397_init function signature is incorrect)

### DIFF
--- a/components/bm1397/bm1397.c
+++ b/components/bm1397/bm1397.c
@@ -217,7 +217,7 @@ void BM1397_send_hash_frequency(float frequency)
     ESP_LOGI(TAG, "Setting Frequency to %.2fMHz (%.2f)", frequency, newf);
 }
 
-static void _send_init(uint64_t frequency, uint16_t asic_count)
+static uint8_t _send_init(uint64_t frequency, uint16_t asic_count)
 {
     // send the init command
     _send_read_address();
@@ -264,6 +264,8 @@ static void _send_init(uint64_t frequency, uint16_t asic_count)
     BM1397_set_default_baud();
 
     BM1397_send_hash_frequency(frequency);
+
+    return chip_counter;
 }
 
 // reset the BM1397 via the RTS line
@@ -281,7 +283,7 @@ static void _reset(void)
     vTaskDelay(100 / portTICK_PERIOD_MS);
 }
 
-void BM1397_init(uint64_t frequency, uint16_t asic_count)
+uint8_t BM1397_init(uint64_t frequency, uint16_t asic_count)
 {
     ESP_LOGI(TAG, "Initializing BM1397");
 
@@ -293,7 +295,7 @@ void BM1397_init(uint64_t frequency, uint16_t asic_count)
     // reset the bm1397
     _reset();
 
-    _send_init(frequency, asic_count);
+    return _send_init(frequency, asic_count);
 }
 
 // Baud formula = 25M/((denominator+1)*8)

--- a/components/bm1397/include/bm1397.h
+++ b/components/bm1397/include/bm1397.h
@@ -46,7 +46,7 @@ typedef struct __attribute__((__packed__))
     uint8_t midstate3[32];
 } job_packet;
 
-void BM1397_init(uint64_t frequency, uint16_t asic_count);
+uint8_t BM1397_init(uint64_t frequency, uint16_t asic_count);
 
 void BM1397_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1397_set_job_difficulty_mask(int);


### PR DESCRIPTION
Function `void BM1397_init(uint64_t, uint16_t)` signature is incompatible with the function pointer `.init_fn` in `AsicFunctions`.
This PR fixes #245 (this issue) by changing the function's return type to `uint8_t`.

This PR also change the return type of function `_send_init()`in bm1397.c from `void` to `uint8_t`.