### PR TITLE
Overheat mode

### DIFF
--- a/config.cvs.example
+++ b/config.cvs.example
@@ -17,3 +17,4 @@ invertfanpol,data,u16,1
 autofanspeed,data,u16,1
 fanspeed,data,u16,100
 selftest,data,u16,1
+overheat,data,u16,0

--- a/main/http_server/axe-os/src/app/components/edit/edit.component.html
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.html
@@ -147,7 +147,7 @@
             </div>
         </div>
 
-        <div class="col-12 md:col-4">
+        <div class="col-12 md:col-4" *ngIf="form.get('overheat')?.value === 1">
             <div class="field-checkbox">
                 <p-checkbox name="overheat" formControlName="overheat" inputId="overheat"
                     [binary]="true"></p-checkbox>

--- a/main/http_server/axe-os/src/app/components/edit/edit.component.html
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.html
@@ -151,7 +151,7 @@
             <div class="field-checkbox">
                 <p-checkbox name="overheat" formControlName="overheat" inputId="overheat"
                     [binary]="true"></p-checkbox>
-                <label for="diagnostics">Disable Overheat Mode. Make sure to reset Frequency and Voltage</label>
+                <label for="overheat">Disable Overheat Mode. Make sure to reset Frequency and Voltage</label>
             </div>
         </div>
 

--- a/main/http_server/axe-os/src/app/components/edit/edit.component.html
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.html
@@ -147,6 +147,13 @@
             </div>
         </div>
 
+        <div class="col-12 md:col-4">
+            <div class="field-checkbox">
+                <p-checkbox name="overheat" formControlName="overheat" inputId="overheat"
+                    [binary]="true"></p-checkbox>
+                <label for="diagnostics">Disable Overheat Mode. Make sure to reset Frequency and Voltage</label>
+            </div>
+        </div>
 
         <div *ngIf="form.controls['autofanspeed'].value != true">
             <div class="col-12" *ngIf="form.controls['autofanspeed'].value != true">

--- a/main/http_server/axe-os/src/app/components/edit/edit.component.ts
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.ts
@@ -137,6 +137,7 @@ export class EditComponent implements OnInit {
           autofanspeed: [info.autofanspeed == 1, [Validators.required]],
           invertfanpolarity: [info.invertfanpolarity == 1, [Validators.required]],
           fanspeed: [info.fanspeed, [Validators.required]],
+          overheat: [info.overheat]
         });
 
         this.form.controls['autofanspeed'].valueChanges.pipe(

--- a/main/http_server/axe-os/src/app/components/edit/edit.component.ts
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.ts
@@ -137,7 +137,7 @@ export class EditComponent implements OnInit {
           autofanspeed: [info.autofanspeed == 1, [Validators.required]],
           invertfanpolarity: [info.invertfanpolarity == 1, [Validators.required]],
           fanspeed: [info.fanspeed, [Validators.required]],
-          overheat: [info.overheat]
+          overheat: [info.overheat, [Validators.required]]
         });
 
         this.form.controls['autofanspeed'].valueChanges.pipe(
@@ -174,6 +174,8 @@ export class EditComponent implements OnInit {
     if (form.stratumPassword === 'password') {
       delete form.stratumPassword;
     }
+
+    form.overheat = form.overheat ? 1 : 0;
 
     this.systemService.updateSystem(this.uri, form)
       .pipe(this.loadingService.lockUIUntilComplete())

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -56,7 +56,8 @@ export class SystemService {
           fanrpm: 0,
 
           boardtemp1: 30,
-          boardtemp2: 40
+          boardtemp2: 40,
+          overheat: 0
         }
       ).pipe(delay(1000));
     }

--- a/main/http_server/axe-os/src/models/ISystemInfo.ts
+++ b/main/http_server/axe-os/src/models/ISystemInfo.ts
@@ -36,5 +36,6 @@ export interface ISystemInfo {
     coreVoltageActual: number,
 
     boardtemp1?: number,
-    boardtemp2?: number
+    boardtemp2?: number,
+    overheat: number
 }

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -296,8 +296,8 @@ static esp_err_t PATCH_update_settings(httpd_req_t * req)
     if ((item = cJSON_GetObjectItem(root, "flipscreen")) != NULL) {
         nvs_config_set_u16(NVS_CONFIG_FLIP_SCREEN, item->valueint);
     }
-    if ((item = cJSON_GetObjectItem(root, "overheat")) == 1) {
-        nvs_config_set_u16(NVS_CONFIG_OVERHEAT_MODE, item->0);
+    if ((item = cJSON_GetObjectItem(root, "overheat")) != NULL) {
+        nvs_config_set_u16(NVS_CONFIG_OVERHEAT_MODE, 0);
     }
     if ((item = cJSON_GetObjectItem(root, "invertscreen")) != NULL) {
         nvs_config_set_u16(NVS_CONFIG_INVERT_SCREEN, item->valueint);

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -296,6 +296,9 @@ static esp_err_t PATCH_update_settings(httpd_req_t * req)
     if ((item = cJSON_GetObjectItem(root, "flipscreen")) != NULL) {
         nvs_config_set_u16(NVS_CONFIG_FLIP_SCREEN, item->valueint);
     }
+    if ((item = cJSON_GetObjectItem(root, "overheat")) == 1) {
+        nvs_config_set_u16(NVS_CONFIG_OVERHEAT_MODE, item->0);
+    }
     if ((item = cJSON_GetObjectItem(root, "invertscreen")) != NULL) {
         nvs_config_set_u16(NVS_CONFIG_INVERT_SCREEN, item->valueint);
     }
@@ -412,6 +415,7 @@ static esp_err_t GET_system_info(httpd_req_t * req)
     cJSON_AddStringToObject(root, "runningPartition", esp_ota_get_running_partition()->label);
 
     cJSON_AddNumberToObject(root, "flipscreen", nvs_config_get_u16(NVS_CONFIG_FLIP_SCREEN, 1));
+    cJSON_AddNumberToObject(root, "overheat", nvs_config_get_u16(NVS_CONFIG_OVERHEAT_MODE,0));
     cJSON_AddNumberToObject(root, "invertscreen", nvs_config_get_u16(NVS_CONFIG_INVERT_SCREEN, 0));
 
     cJSON_AddNumberToObject(root, "invertfanpolarity", nvs_config_get_u16(NVS_CONFIG_INVERT_FAN_POLARITY, 1));

--- a/main/nvs_config.h
+++ b/main/nvs_config.h
@@ -24,6 +24,7 @@
 #define NVS_CONFIG_FAN_SPEED "fanspeed"
 #define NVS_CONFIG_BEST_DIFF "bestdiff"
 #define NVS_CONFIG_SELF_TEST "selftest"
+#define NVS_CONFIG_OVERHEAT_MODE "overheat_mode"
 
 #define NVS_CONFIG_SWARM "swarmconfig"
 

--- a/main/tasks/power_management_task.c
+++ b/main/tasks/power_management_task.c
@@ -197,6 +197,7 @@ void POWER_MANAGEMENT_task(void * pvParameters)
                         nvs_config_set_u16(NVS_CONFIG_ASIC_FREQ, 50);
                         nvs_config_set_u16(NVS_CONFIG_FAN_SPEED, 100);
                         nvs_config_set_u16(NVS_CONFIG_AUTO_FAN_SPEED, 0);
+                        nvs_config_set_u16(NVS_CONFIG_OVERHEAT_MODE, 1);
                         exit(EXIT_FAILURE);
 					}
 


### PR DESCRIPTION
Implementing the Overheat_mode

Features:

- If Overheat_mode enabled --> Overheat screen will be shown until disabled in WebUI
- Added Disabled Button in the WebUI for the Overheat_mode --> User awareness of the overheating issue

This should lower the potential of user not knowing why there machine is no longer hashing and rising the awareness of potential overheating scenarios therefore, the user hopefully changes the cooling or performs other changes.