### PR TITLE
Fix free heap memory decreasing

### DIFF
--- a/main/nvs_config.c
+++ b/main/nvs_config.c
@@ -67,12 +67,13 @@ uint16_t nvs_config_get_u16(const char * key, const uint16_t default_value)
 
     uint16_t out;
     err = nvs_get_u16(handle, key, &out);
+    
+    nvs_close(handle);
 
     if (err != ESP_OK) {
         return default_value;
     }
 
-    nvs_close(handle);
     return out;
 }
 


### PR DESCRIPTION
After checking the recent commits, I found this phenomenon starts after adding the overheat mode feature.

The nvs_config_get_u16 function is used in the while statement in SYSTEM_task to get the current status. After I checked the code of this function, I found that the function that returns the default value is called before nvs_close(handle). After changing the calling order, the phenomenon of free heap memory decreasing disappeared.