### PR TITLE
clear ASIC RX serial buffer on framing errors

### DIFF
--- a/components/bm1397/bm1366.c
+++ b/components/bm1397/bm1366.c
@@ -96,7 +96,7 @@ static void _send_BM1366(uint8_t header, uint8_t * data, uint8_t data_len, bool 
     }
 
     // send serial data
-    SERIAL_send(buf, total_length, BM1366_DEBUG_CHIP_SERIAL);
+    SERIAL_send(buf, total_length, debug);
 
     free(buf);
 }
@@ -105,7 +105,7 @@ static void _send_simple(uint8_t * data, uint8_t total_length)
 {
     unsigned char * buf = malloc(total_length);
     memcpy(buf, data, total_length);
-    SERIAL_send(buf, total_length, BM1366_DEBUG_CHIP_SERIAL);
+    SERIAL_send(buf, total_length, BM1366_SERIALTX_DEBUG);
 
     free(buf);
 }
@@ -115,7 +115,7 @@ static void _send_chain_inactive(void)
 
     unsigned char read_address[2] = {0x00, 0x00};
     // send serial data
-    _send_BM1366((TYPE_CMD | GROUP_ALL | CMD_INACTIVE), read_address, 2, false);
+    _send_BM1366((TYPE_CMD | GROUP_ALL | CMD_INACTIVE), read_address, 2, BM1366_SERIALTX_DEBUG);
 }
 
 static void _set_chip_address(uint8_t chipAddr)
@@ -123,7 +123,7 @@ static void _set_chip_address(uint8_t chipAddr)
 
     unsigned char read_address[2] = {chipAddr, 0x00};
     // send serial data
-    _send_BM1366((TYPE_CMD | GROUP_SINGLE | CMD_SETADDRESS), read_address, 2, false);
+    _send_BM1366((TYPE_CMD | GROUP_SINGLE | CMD_SETADDRESS), read_address, 2, BM1366_SERIALTX_DEBUG);
 }
 
 void BM1366_send_hash_frequency(float target_freq)
@@ -179,7 +179,7 @@ void BM1366_send_hash_frequency(float target_freq)
         }
     }
 
-    _send_BM1366((TYPE_CMD | GROUP_ALL | CMD_WRITE), freqbuf, 6, false);
+    _send_BM1366((TYPE_CMD | GROUP_ALL | CMD_WRITE), freqbuf, 6, BM1366_SERIALTX_DEBUG);
 
     ESP_LOGI(TAG, "Setting Frequency to %.2fMHz (%.2f)", target_freq, newf);
 }
@@ -467,15 +467,15 @@ static uint8_t _send_init(uint64_t frequency, uint16_t asic_count)
 
     for (uint8_t i = 0; i < chip_counter; i++) {
         unsigned char set_a8_register[6] = {i * address_interval, 0xA8, 0x00, 0x07, 0x01, 0xF0};
-        _send_BM1366((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_a8_register, 6, false);
+        _send_BM1366((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_a8_register, 6, BM1366_SERIALTX_DEBUG);
         unsigned char set_18_register[6] = {i * address_interval, 0x18, 0xF0, 0x00, 0xC1, 0x00};
-        _send_BM1366((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_18_register, 6, false);
+        _send_BM1366((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_18_register, 6, BM1366_SERIALTX_DEBUG);
         unsigned char set_3c_register_first[6] = {i * address_interval, 0x3C, 0x80, 0x00, 0x85, 0x40};
-        _send_BM1366((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_3c_register_first, 6, false);
+        _send_BM1366((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_3c_register_first, 6, BM1366_SERIALTX_DEBUG);
         unsigned char set_3c_register_second[6] = {i * address_interval, 0x3C, 0x80, 0x00, 0x80, 0x20};
-        _send_BM1366((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_3c_register_second, 6, false);
+        _send_BM1366((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_3c_register_second, 6, BM1366_SERIALTX_DEBUG);
         unsigned char set_3c_register_third[6] = {i * address_interval, 0x3C, 0x80, 0x00, 0x82, 0xAA};
-        _send_BM1366((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_3c_register_third, 6, false);
+        _send_BM1366((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_3c_register_third, 6, BM1366_SERIALTX_DEBUG);
     }
 
     do_frequency_ramp_up();
@@ -488,7 +488,7 @@ static uint8_t _send_init(uint64_t frequency, uint16_t asic_count)
     // unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x14, 0x46}; //S19XP-Luxos Default
     unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x15, 0x1C}; //S19XP-Stock Default
     // unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x0F, 0x00, 0x00}; //supposedly the "full" 32bit nonce range
-    _send_BM1366((TYPE_CMD | GROUP_ALL | CMD_WRITE), set_10_hash_counting, 6, false);
+    _send_BM1366((TYPE_CMD | GROUP_ALL | CMD_WRITE), set_10_hash_counting, 6, BM1366_SERIALTX_DEBUG);
 
     unsigned char init795[11] = {0x55, 0xAA, 0x51, 0x09, 0x00, 0xA4, 0x90, 0x00, 0xFF, 0xFF, 0x1C};
     _send_simple(init795, 11);
@@ -516,7 +516,7 @@ static void _send_read_address(void)
 
     unsigned char read_address[2] = {0x00, 0x00};
     // send serial data
-    _send_BM1366((TYPE_CMD | GROUP_ALL | CMD_READ), read_address, 2, false);
+    _send_BM1366((TYPE_CMD | GROUP_ALL | CMD_READ), read_address, 2, BM1366_SERIALTX_DEBUG);
 }
 
 uint8_t BM1366_init(uint64_t frequency, uint16_t asic_count)
@@ -540,7 +540,7 @@ int BM1366_set_default_baud(void)
 {
     // default divider of 26 (11010) for 115,749
     unsigned char baudrate[9] = {0x00, MISC_CONTROL, 0x00, 0x00, 0b01111010, 0b00110001}; // baudrate - misc_control
-    _send_BM1366((TYPE_CMD | GROUP_ALL | CMD_WRITE), baudrate, 6, false);
+    _send_BM1366((TYPE_CMD | GROUP_ALL | CMD_WRITE), baudrate, 6, BM1366_SERIALTX_DEBUG);
     return 115749;
 }
 
@@ -584,7 +584,7 @@ void BM1366_set_job_difficulty_mask(int difficulty)
 
     ESP_LOGI(TAG, "Setting job ASIC mask to %d", difficulty);
 
-    _send_BM1366((TYPE_CMD | GROUP_ALL | CMD_WRITE), job_difficulty_mask, 6, false);
+    _send_BM1366((TYPE_CMD | GROUP_ALL | CMD_WRITE), job_difficulty_mask, 6, BM1366_SERIALTX_DEBUG);
 }
 
 static uint8_t id = 0;
@@ -615,10 +615,12 @@ void BM1366_send_work(void * pvParameters, bm_job * next_bm_job)
     GLOBAL_STATE->valid_jobs[job.job_id] = 1;
     
     //debug sent jobs - this can get crazy if the interval is short
-    //ESP_LOGI(TAG, "Send Job: %02X", job.job_id);
+    #if BM1368_DEBUG_JOBS
+    ESP_LOGI(TAG, "Send Job: %02X", job.job_id);
+    #endif
     pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
 
-    _send_BM1366((TYPE_JOB | GROUP_SINGLE | CMD_WRITE), &job, sizeof(BM1366_job), false);
+    _send_BM1366((TYPE_JOB | GROUP_SINGLE | CMD_WRITE), &job, sizeof(BM1366_job), BM1366_DEBUG_WORK);
 }
 
 asic_result * BM1366_receive_work(void)
@@ -637,6 +639,7 @@ asic_result * BM1366_receive_work(void)
     if (received != 11 || asic_response_buffer[0] != 0xAA || asic_response_buffer[1] != 0x55) {
         ESP_LOGI(TAG, "Serial RX invalid %i", received);
         ESP_LOG_BUFFER_HEX(TAG, asic_response_buffer, received);
+        SERIAL_clear_buffer();
         return NULL;
     }
 

--- a/components/bm1397/bm1368.c
+++ b/components/bm1397/bm1368.c
@@ -105,7 +105,7 @@ static void _send_simple(uint8_t * data, uint8_t total_length)
 {
     unsigned char * buf = malloc(total_length);
     memcpy(buf, data, total_length);
-    SERIAL_send(buf, total_length, false);
+    SERIAL_send(buf, total_length, BM1368_SERIALTX_DEBUG);
 
     free(buf);
 }
@@ -115,7 +115,7 @@ static void _send_chain_inactive(void)
 
     unsigned char read_address[2] = {0x00, 0x00};
     // send serial data
-    _send_BM1368((TYPE_CMD | GROUP_ALL | CMD_INACTIVE), read_address, 2, false);
+    _send_BM1368((TYPE_CMD | GROUP_ALL | CMD_INACTIVE), read_address, 2, BM1368_SERIALTX_DEBUG);
 }
 
 static void _set_chip_address(uint8_t chipAddr)
@@ -123,7 +123,7 @@ static void _set_chip_address(uint8_t chipAddr)
 
     unsigned char read_address[2] = {chipAddr, 0x00};
     // send serial data
-    _send_BM1368((TYPE_CMD | GROUP_SINGLE | CMD_SETADDRESS), read_address, 2, false);
+    _send_BM1368((TYPE_CMD | GROUP_SINGLE | CMD_SETADDRESS), read_address, 2, BM1368_SERIALTX_DEBUG);
 }
 
 void BM1368_send_hash_frequency(float target_freq)
@@ -179,7 +179,7 @@ void BM1368_send_hash_frequency(float target_freq)
         }
     }
 
-    _send_BM1368((TYPE_CMD | GROUP_ALL | CMD_WRITE), freqbuf, 6, false);
+    _send_BM1368((TYPE_CMD | GROUP_ALL | CMD_WRITE), freqbuf, 6, BM1368_SERIALTX_DEBUG);
 
     ESP_LOGI(TAG, "Setting Frequency to %.2fMHz (%.2f)", target_freq, newf);
 }
@@ -261,7 +261,7 @@ static void do_frequency_ramp_up() {
         freq_cmd[3] = freq_list[i][1];
         freq_cmd[4] = freq_list[i][2];
         freq_cmd[5] = freq_list[i][3];
-        _send_BM1368((TYPE_CMD | GROUP_ALL | CMD_WRITE), freq_cmd, 6, false);
+        _send_BM1368((TYPE_CMD | GROUP_ALL | CMD_WRITE), freq_cmd, 6, BM1368_SERIALTX_DEBUG);
         vTaskDelay(100 / portTICK_PERIOD_MS);
     }
 }
@@ -344,19 +344,19 @@ static uint8_t _send_init(uint64_t frequency, uint16_t asic_count)
     for (uint8_t i = 0; i < chip_counter; i++) {
         //Reg_A8
         unsigned char set_a8_register[6] = {i * address_interval, 0xA8, 0x00, 0x07, 0x01, 0xF0};
-        _send_BM1368((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_a8_register, 6, false);
+        _send_BM1368((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_a8_register, 6, BM1368_SERIALTX_DEBUG);
         //Misc Control
         unsigned char set_18_register[6] = {i * address_interval, 0x18, 0xF0, 0x00, 0xC1, 0x00};
-        _send_BM1368((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_18_register, 6, false);
+        _send_BM1368((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_18_register, 6, BM1368_SERIALTX_DEBUG);
         //Core Register Control
         unsigned char set_3c_register_first[6] = {i * address_interval, 0x3C, 0x80, 0x00, 0x8B, 0x00};
-        _send_BM1368((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_3c_register_first, 6, false);
+        _send_BM1368((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_3c_register_first, 6, BM1368_SERIALTX_DEBUG);
         //Core Register Control
         unsigned char set_3c_register_second[6] = {i * address_interval, 0x3C, 0x80, 0x00, 0x80, 0x18};
-        _send_BM1368((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_3c_register_second, 6, false);
+        _send_BM1368((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_3c_register_second, 6, BM1368_SERIALTX_DEBUG);
         //Core Register Control
         unsigned char set_3c_register_third[6] = {i * address_interval, 0x3C, 0x80, 0x00, 0x82, 0xAA};
-        _send_BM1368((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_3c_register_third, 6, false);
+        _send_BM1368((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_3c_register_third, 6, BM1368_SERIALTX_DEBUG);
     }
 
     do_frequency_ramp_up();
@@ -370,7 +370,7 @@ static uint8_t _send_init(uint64_t frequency, uint16_t asic_count)
     // unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x15, 0x1C}; //S19XP-Stock Default
     unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x15, 0xA4}; //S21-Stock Default
     // unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x0F, 0x00, 0x00}; //supposedly the "full" 32bit nonce range
-    _send_BM1368((TYPE_CMD | GROUP_ALL | CMD_WRITE), set_10_hash_counting, 6, false);
+    _send_BM1368((TYPE_CMD | GROUP_ALL | CMD_WRITE), set_10_hash_counting, 6, BM1368_SERIALTX_DEBUG);
 
     return chip_counter;
 }
@@ -395,7 +395,7 @@ static void _send_read_address(void)
 
     unsigned char read_address[2] = {0x00, 0x00};
     // send serial data
-    _send_BM1368((TYPE_CMD | GROUP_ALL | CMD_READ), read_address, 2, false);
+    _send_BM1368((TYPE_CMD | GROUP_ALL | CMD_READ), read_address, 2, BM1368_SERIALTX_DEBUG);
 }
 
 uint8_t BM1368_init(uint64_t frequency, uint16_t asic_count)
@@ -419,7 +419,7 @@ int BM1368_set_default_baud(void)
 {
     // default divider of 26 (11010) for 115,749
     unsigned char baudrate[9] = {0x00, MISC_CONTROL, 0x00, 0x00, 0b01111010, 0b00110001}; // baudrate - misc_control
-    _send_BM1368((TYPE_CMD | GROUP_ALL | CMD_WRITE), baudrate, 6, false);
+    _send_BM1368((TYPE_CMD | GROUP_ALL | CMD_WRITE), baudrate, 6, BM1368_SERIALTX_DEBUG);
     return 115749;
 }
 
@@ -462,7 +462,7 @@ void BM1368_set_job_difficulty_mask(int difficulty)
 
     ESP_LOGI(TAG, "Setting ASIC difficulty mask to %d", difficulty);
 
-    _send_BM1368((TYPE_CMD | GROUP_ALL | CMD_WRITE), job_difficulty_mask, 6, false);
+    _send_BM1368((TYPE_CMD | GROUP_ALL | CMD_WRITE), job_difficulty_mask, 6, BM1368_SERIALTX_DEBUG);
 }
 
 static uint8_t id = 0;
@@ -491,10 +491,10 @@ void BM1368_send_work(void * pvParameters, bm_job * next_bm_job)
 
     pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
     GLOBAL_STATE->valid_jobs[job.job_id] = 1;
-    //ESP_LOGI(TAG, "Send Job: %02X", job.job_id);
+    ESP_LOGI(TAG, "Send Job: %02X", job.job_id);
     pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
 
-    _send_BM1368((TYPE_JOB | GROUP_SINGLE | CMD_WRITE), &job, sizeof(BM1368_job), false);
+    _send_BM1368((TYPE_JOB | GROUP_SINGLE | CMD_WRITE), &job, sizeof(BM1368_job), BM1368_DEBUG_WORK);
 }
 
 asic_result * BM1368_receive_work(void)
@@ -511,8 +511,9 @@ asic_result * BM1368_receive_work(void)
     }
 
     if (received != 11 || asic_response_buffer[0] != 0xAA || asic_response_buffer[1] != 0x55) {
-        ESP_LOGI(TAG, "Serial RX invalid %i", received);
+        ESP_LOGE(TAG, "Serial RX invalid %i", received);
         ESP_LOG_BUFFER_HEX(TAG, asic_response_buffer, received);
+        SERIAL_clear_buffer();
         return NULL;
     }
 

--- a/components/bm1397/bm1368.c
+++ b/components/bm1397/bm1368.c
@@ -491,7 +491,10 @@ void BM1368_send_work(void * pvParameters, bm_job * next_bm_job)
 
     pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
     GLOBAL_STATE->valid_jobs[job.job_id] = 1;
+
+    #if BM1368_DEBUG_JOBS
     ESP_LOGI(TAG, "Send Job: %02X", job.job_id);
+    #endif
     pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
 
     _send_BM1368((TYPE_JOB | GROUP_SINGLE | CMD_WRITE), &job, sizeof(BM1368_job), BM1368_DEBUG_WORK);

--- a/components/bm1397/include/bm1366.h
+++ b/components/bm1397/include/bm1366.h
@@ -8,7 +8,10 @@
 #define CRC5_MASK 0x1F
 #define BM1366_INITIAL_DIFFICULTY 256
 
-#define BM1366_DEBUG_CHIP_SERIAL false
+#define BM1366_SERIALTX_DEBUG false
+#define BM1366_SERIALRX_DEBUG false
+#define BM1366_DEBUG_WORK false //causes insane amount of debug output
+#define BM1368_DEBUG_JOBS true //causes insane amount of debug output
 
 static const uint64_t BM1366_CORE_COUNT = 112;
 static const uint64_t BM1366_SMALL_CORE_COUNT = 894;

--- a/components/bm1397/include/bm1366.h
+++ b/components/bm1397/include/bm1366.h
@@ -11,7 +11,7 @@
 #define BM1366_SERIALTX_DEBUG false
 #define BM1366_SERIALRX_DEBUG false
 #define BM1366_DEBUG_WORK false //causes insane amount of debug output
-#define BM1368_DEBUG_JOBS true //causes insane amount of debug output
+#define BM1368_DEBUG_JOBS false //causes insane amount of debug output
 
 static const uint64_t BM1366_CORE_COUNT = 112;
 static const uint64_t BM1366_SMALL_CORE_COUNT = 894;

--- a/components/bm1397/include/bm1368.h
+++ b/components/bm1397/include/bm1368.h
@@ -6,13 +6,12 @@
 #include "mining.h"
 
 #define CRC5_MASK 0x1F
-
 #define BM1368_INITIAL_DIFFICULTY 256
 
-#define BM1368_SERIALTX_DEBUG true
-#define BM1368_SERIALRX_DEBUG true
+#define BM1368_SERIALTX_DEBUG false
+#define BM1368_SERIALRX_DEBUG false
 #define BM1368_DEBUG_WORK false //causes insane amount of debug output
-#define BM1368_DEBUG_JOBS true //causes insane amount of debug output
+#define BM1368_DEBUG_JOBS false //causes insane amount of debug output
 
 static const uint64_t BM1368_CORE_COUNT = 80;
 static const uint64_t BM1368_SMALL_CORE_COUNT = 1276;

--- a/components/bm1397/include/bm1368.h
+++ b/components/bm1397/include/bm1368.h
@@ -12,6 +12,7 @@
 #define BM1368_SERIALTX_DEBUG true
 #define BM1368_SERIALRX_DEBUG true
 #define BM1368_DEBUG_WORK false //causes insane amount of debug output
+#define BM1368_DEBUG_JOBS true //causes insane amount of debug output
 
 static const uint64_t BM1368_CORE_COUNT = 80;
 static const uint64_t BM1368_SMALL_CORE_COUNT = 1276;

--- a/components/bm1397/include/bm1368.h
+++ b/components/bm1397/include/bm1368.h
@@ -9,6 +9,10 @@
 
 #define BM1368_INITIAL_DIFFICULTY 256
 
+#define BM1368_SERIALTX_DEBUG true
+#define BM1368_SERIALRX_DEBUG true
+#define BM1368_DEBUG_WORK false //causes insane amount of debug output
+
 static const uint64_t BM1368_CORE_COUNT = 80;
 static const uint64_t BM1368_SMALL_CORE_COUNT = 1276;
 

--- a/components/bm1397/serial.c
+++ b/components/bm1397/serial.c
@@ -69,11 +69,13 @@ int16_t SERIAL_rx(uint8_t *buf, uint16_t size, uint16_t timeout_ms)
 {
     int16_t bytes_read = uart_read_bytes(UART_NUM_1, buf, size, timeout_ms / portTICK_PERIOD_MS);
 
-    #if BM1937_SERIALRX_DEBUG || BM1368_SERIALRX_DEBUG
+    #if BM1937_SERIALRX_DEBUG || BM1366_SERIALRX_DEBUG || BM1368_SERIALRX_DEBUG
+    size_t buff_len = 0;
     if (bytes_read > 0) {
+        uart_get_buffered_data_len(UART_NUM_1, &buff_len);
         printf("rx: ");
         prettyHex((unsigned char*) buf, bytes_read);
-        printf("\n");
+        printf(" [%d]\n", buff_len);
     }
     #endif
 

--- a/components/bm1397/serial.c
+++ b/components/bm1397/serial.c
@@ -10,6 +10,7 @@
 #include "soc/uart_struct.h"
 
 #include "bm1397.h"
+#include "bm1368.h"
 #include "serial.h"
 #include "utils.h"
 
@@ -68,7 +69,7 @@ int16_t SERIAL_rx(uint8_t *buf, uint16_t size, uint16_t timeout_ms)
 {
     int16_t bytes_read = uart_read_bytes(UART_NUM_1, buf, size, timeout_ms / portTICK_PERIOD_MS);
 
-    #if BM1937_SERIALRX_DEBUG
+    #if BM1937_SERIALRX_DEBUG || BM1368_SERIALRX_DEBUG
     if (bytes_read > 0) {
         printf("rx: ");
         prettyHex((unsigned char*) buf, bytes_read);

--- a/components/stratum/utils.c
+++ b/components/stratum/utils.c
@@ -291,7 +291,7 @@ void prettyHex(unsigned char *buf, int len)
     {
         printf("%02X ", buf[i]);
     }
-    printf("%02X]\n", buf[len - 1]);
+    printf("%02X]", buf[len - 1]);
 }
 
 uint32_t flip32(uint32_t val)


### PR DESCRIPTION
When an 11 byte ASIC serial rx packet comes in that doesn't start with AA 55, drop it and now clear the whole serial buffer