### PR TITLE
minor change to ckpool quicklink detector

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -147,7 +147,7 @@ export class HomeComponent {
         } else if (info.stratumURL.includes('solo.d-central.tech')) {
           const address = info.stratumUser.split('.')[0]
           return `https://solo.d-central.tech/#/app/${address}`;
-        } else if (info.stratumURL.includes('solo.ckpool.org')) {
+        } else if (/solo[46]?.ckpool.org/.test(info.stratumURL)) {
           const address = info.stratumUser.split('.')[0]
           return `https://solostats.ckpool.org/stats/${address}`;
         } else {


### PR DESCRIPTION
Minor change allows detection of `solo4.ckpool.org` or `solo6.ckpool.org` in addition to `solo.ckpool.org`.