### PR TITLE
Fix precision for devices reaching TH/s

### DIFF
--- a/main/http_server/axe-os/src/app/pipes/hash-suffix.pipe.ts
+++ b/main/http_server/axe-os/src/app/pipes/hash-suffix.pipe.ts
@@ -26,7 +26,10 @@ export class HashSuffixPipe implements PipeTransform {
     const scaledValue = value / Math.pow(1000, power);
     const suffix = suffixes[power];
 
-    return scaledValue.toFixed(2) + suffix;
+    if (power > 3) {
+      return scaledValue.toFixed(2) + suffix;
+    }
+    return scaledValue.toFixed(1) + suffix;
   }
 
 

--- a/main/http_server/axe-os/src/app/pipes/hash-suffix.pipe.ts
+++ b/main/http_server/axe-os/src/app/pipes/hash-suffix.pipe.ts
@@ -26,7 +26,7 @@ export class HashSuffixPipe implements PipeTransform {
     const scaledValue = value / Math.pow(1000, power);
     const suffix = suffixes[power];
 
-    return scaledValue.toFixed(1) + suffix;
+    return scaledValue.toFixed(2) + suffix;
   }
 
 


### PR DESCRIPTION
This fixes the precision for the graph when reaching 1 TH/s+.
![image](https://github.com/user-attachments/assets/cb3050dc-3751-4ab7-a911-43a21399ae80)
