### PR TITLE
nvs memory fix

### DIFF
--- a/main/nvs_config.c
+++ b/main/nvs_config.c
@@ -20,6 +20,7 @@ char * nvs_config_get_string(const char * key, const char * default_value)
     err = nvs_get_str(handle, key, NULL, &size);
 
     if (err != ESP_OK) {
+        nvs_close(handle);
         return strdup(default_value);
     }
 
@@ -28,6 +29,7 @@ char * nvs_config_get_string(const char * key, const char * default_value)
 
     if (err != ESP_OK) {
         free(out);
+        nvs_close(handle);
         return strdup(default_value);
     }
 
@@ -49,11 +51,9 @@ void nvs_config_set_string(const char * key, const char * value)
     err = nvs_set_str(handle, key, value);
     if (err != ESP_OK) {
         ESP_LOGW(TAG, "Could not write nvs key: %s, value: %s", key, value);
-        return;
     }
 
     nvs_close(handle);
-    return;
 }
 
 uint16_t nvs_config_get_u16(const char * key, const uint16_t default_value)
@@ -68,7 +68,7 @@ uint16_t nvs_config_get_u16(const char * key, const uint16_t default_value)
     uint16_t out;
     err = nvs_get_u16(handle, key, &out);
     nvs_close(handle);
-    
+
     if (err != ESP_OK) {
         return default_value;
     }
@@ -89,11 +89,9 @@ void nvs_config_set_u16(const char * key, const uint16_t value)
     err = nvs_set_u16(handle, key, value);
     if (err != ESP_OK) {
         ESP_LOGW(TAG, "Could not write nvs key: %s, value: %u", key, value);
-        return;
     }
 
     nvs_close(handle);
-    return;
 }
 
 uint64_t nvs_config_get_u64(const char * key, const uint64_t default_value)
@@ -109,6 +107,7 @@ uint64_t nvs_config_get_u64(const char * key, const uint64_t default_value)
     err = nvs_get_u64(handle, key, &out);
 
     if (err != ESP_OK) {
+        nvs_close(handle);
         return default_value;
     }
 
@@ -130,8 +129,6 @@ void nvs_config_set_u64(const char * key, const uint64_t value)
     err = nvs_set_u64(handle, key, value);
     if (err != ESP_OK) {
         ESP_LOGW(TAG, "Could not write nvs key: %s, value: %llu", key, value);
-        return;
     }
     nvs_close(handle);
-    return;
 }


### PR DESCRIPTION
fixes memory leak when web UI is opened.

web UI requests `/info` which loads strings from `nvs` everytime it is called.

`nvs_close` was not called in all cases.