### PR TITLE
Fix wifi status not updating after disconnected #320

### DIFF
--- a/components/connect/connect.c
+++ b/components/connect/connect.c
@@ -75,6 +75,7 @@ static void event_handler(void * arg, esp_event_base_t event_base, int32_t event
         ESP_LOGI(TAG, "Bitaxe ip:" IPSTR, IP2STR(&event->ip_info.ip));
         s_retry_num = 0;
         xEventGroupSetBits(s_wifi_event_group, WIFI_CONNECTED_BIT);
+        MINER_set_wifi_status(WIFI_CONNECTED, 0);
     }
 }
 

--- a/main/main.c
+++ b/main/main.c
@@ -217,7 +217,11 @@ void app_main(void)
 
 void MINER_set_wifi_status(wifi_status_t status, uint16_t retry_count)
 {
-    if (status == WIFI_RETRYING) {
+    if (status == WIFI_CONNECTED) {
+        snprintf(GLOBAL_STATE.SYSTEM_MODULE.wifi_status, 20, "Connected!");
+        return;
+    }
+    else if (status == WIFI_RETRYING) {
         snprintf(GLOBAL_STATE.SYSTEM_MODULE.wifi_status, 20, "Retrying: %d", retry_count);
         return;
     } else if (status == WIFI_CONNECT_FAILED) {


### PR DESCRIPTION
This should fix https://github.com/skot/ESP-Miner/issues/320

Steps to reproduce
1) Connect device to WiFi.
2) Restart WiFi Router / AP.
3) Reconnect to device. WebUI should now say `Connected!`.