### PR TITLE
Protect against negative frequency and voltage values

### DIFF
--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -290,10 +290,10 @@ static esp_err_t PATCH_update_settings(httpd_req_t * req)
     if ((item = cJSON_GetObjectItem(root, "hostname")) != NULL) {
         nvs_config_set_string(NVS_CONFIG_HOSTNAME, item->valuestring);
     }
-    if ((item = cJSON_GetObjectItem(root, "coreVoltage")) != NULL) {
+    if ((item = cJSON_GetObjectItem(root, "coreVoltage")) != NULL && item->valueint > 0) {
         nvs_config_set_u16(NVS_CONFIG_ASIC_VOLTAGE, item->valueint);
     }
-    if ((item = cJSON_GetObjectItem(root, "frequency")) != NULL) {
+    if ((item = cJSON_GetObjectItem(root, "frequency")) != NULL && item->valueint > 0) {
         nvs_config_set_u16(NVS_CONFIG_ASIC_FREQ, item->valueint);
     }
     if ((item = cJSON_GetObjectItem(root, "flipscreen")) != NULL) {


### PR DESCRIPTION
Testing the new freq code I tried to input some silly values, e.g. `-1` and it caused frequency to ramp up endlessly (potentially bricking the device) due to an int underflow.
