### PR TITLE
Increase the max number of log lines stored in browser

### DIFF
--- a/main/http_server/axe-os/src/app/components/logs/logs.component.ts
+++ b/main/http_server/axe-os/src/app/components/logs/logs.component.ts
@@ -56,7 +56,7 @@ export class LogsComponent implements OnDestroy, AfterViewChecked {
       this.websocketSubscription = this.websocketService.ws$.subscribe({
         next: (val) => {
           this.logs.push(val);
-          if (this.logs.length > 100) {
+          if (this.logs.length > 256) {
             this.logs.shift();
           }
         }


### PR DESCRIPTION
I think it's worth a few more kb browser memory to store some additional logs. This can be useful when trying to browse startup logs.