### PR TITLE
Remove invalid IPv4 validation in DNS code #329

### DIFF
--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -31,18 +31,15 @@ static SystemTaskModule SYSTEM_TASK_MODULE = {.stratum_difficulty = 8192};
 
 void dns_found_cb(const char * name, const ip_addr_t * ipaddr, void * callback_arg)
 {
-    if ((ipaddr != NULL)){
+    if (ipaddr != NULL){
         ip4_addr_t ip4addr = ipaddr->u_addr.ip4;  // Obtener la estructura ip4_addr_t
-        if (ip4_addr1(&ip4addr) != 0 && ip4_addr2(&ip4addr) != 0 && 
-            ip4_addr3(&ip4addr) != 0 && ip4_addr4(&ip4addr) != 0) {
-            ESP_LOGI(TAG, "IP found : %d.%d.%d.%d",ip4_addr1(&ip4addr),ip4_addr2(&ip4addr),ip4_addr3(&ip4addr),ip4_addr4(&ip4addr));
-            ip_Addr = *ipaddr;
-         }
+        ESP_LOGI(TAG, "IP found : %d.%d.%d.%d", ip4_addr1(&ip4addr), ip4_addr2(&ip4addr), ip4_addr3(&ip4addr), ip4_addr4(&ip4addr));
+        ip_Addr = *ipaddr;
     } else {
         bDNSInvalid = true;
     }
     bDNSFound = true;
- }
+}
 
 bool is_wifi_connected() {
     wifi_ap_record_t ap_info;


### PR DESCRIPTION
This is a fix for the issue with pool records that have a zero in one or more of their IP octets (e.g. `51.81.0.15`). https://github.com/skot/ESP-Miner/issues/329

The issue is that we are checking if one of the octets is a zero and if we get at least one we return without setting the DNS valid flag. If we don't get a zero we pass, but a zero in an IP octet is a perfectly valid value, so we should be passing as long as we aren't getting a null value.

Of course we could be more pedantic here as there are invalid values we could be looking for, but those are very unlikely to be received as valid DNS results, unless they are intentional (e.g. 127.0.0.1 or 0.0.0.0).

tl;dr this logic isn't really necessary and it should be enough to just remove it. Tested with a few pools and custom DNS records.