### PR TITLE
Add support for client.reconnect method in Stratum V1 protocol

### DIFF
--- a/components/stratum/include/stratum_api.h
+++ b/components/stratum/include/stratum_api.h
@@ -59,6 +59,11 @@ typedef struct
     uint32_t version_mask;
     // result
     bool response_success;
+
+    // client.reconnect
+    char *new_host;
+    uint16_t new_port;
+    uint16_t wait_time;
 } StratumApiV1Message;
 
 void STRATUM_V1_reset_uid();

--- a/components/stratum/stratum_api.c
+++ b/components/stratum/stratum_api.c
@@ -258,6 +258,35 @@ void STRATUM_V1_parse(StratumApiV1Message * message, const char * stratum_json)
         cJSON * params = cJSON_GetObjectItem(json, "params");
         uint32_t version_mask = strtoul(cJSON_GetArrayItem(params, 0)->valuestring, NULL, 16);
         message->version_mask = version_mask;
+    } else if (message->method == CLIENT_RECONNECT) {
+        cJSON * params = cJSON_GetObjectItem(json, "params");
+        if (params != NULL && cJSON_IsArray(params)) {
+            cJSON * host = cJSON_GetArrayItem(params, 0);
+            cJSON * port = cJSON_GetArrayItem(params, 1);
+            cJSON * wait = cJSON_GetArrayItem(params, 2);
+
+            if (host && cJSON_IsString(host)) {
+                message->new_host = strdup(host->valuestring);
+            } else {
+                message->new_host = NULL;
+            }
+
+            if (port && cJSON_IsNumber(port)) {
+                message->new_port = (uint16_t)port->valueint;
+            } else {
+                message->new_port = 0;
+            }
+
+            if (wait && cJSON_IsNumber(wait)) {
+                message->wait_time = (uint16_t)wait->valueint;
+            } else {
+                message->wait_time = 0;
+            }
+
+            ESP_LOGI(TAG, "Received client.reconnect: host=%s, port=%u, wait=%u",
+                     message->new_host ? message->new_host : "NULL",
+                     message->new_port, message->wait_time);
+        }
     }
     done:
     cJSON_Delete(json);


### PR DESCRIPTION
#41 

This adds support for the client.reconnect method. This allows the miner to handle client.reconnect messages sent by pools, setting the miner to reconnect to a different host and port, optionally after a specified wait time (defaults to 1 second). 

Changes:
- added fields to stratum_api.h
- added parsing the json msgs from the CLIENT_RECONNECT method
- on reconnect, close the current connection and connect to the new one
- improved socket handling by marking the socket as invalid (-1) whenever it's closed




Test instructions:

1. Setup the [mock server](https://github.com/bears-fan/mock-stratum-v1-server) and start the server with default settings `python3 server.py`
2. Point the bitaxe at the mock server
3. While the server is running, use the command `reconnect`, enter host `public-pool.io` and port `21496`
4. Follow the bitaxe logs to verify expected usage. Should see a log entry similar to `Received client.reconnect: host=public-pool.io, port=21496, wait=10
`
5. The miner should gracefully close the connection and connect after the wait time specified

