### PR TITLE
Legacy selftest fixes

### DIFF
--- a/main/self_test/self_test.c
+++ b/main/self_test/self_test.c
@@ -13,10 +13,10 @@
 #include "string.h"
 #include "TPS546.h"
 
-#define POWER_CONSUMPTION_TARGET_SUB_402 12     //volts
-#define POWER_CONSUMPTION_TARGET_402 8          //volts
-#define POWER_CONSUMPTION_TARGET_GAMMA 11       //volts
-#define POWER_CONSUMPTION_MARGIN 3              //+/- volts
+#define POWER_CONSUMPTION_TARGET_SUB_402 12     //watts
+#define POWER_CONSUMPTION_TARGET_402 5          //watts
+#define POWER_CONSUMPTION_TARGET_GAMMA 11       //watts
+#define POWER_CONSUMPTION_MARGIN 3              //+/- watts
 
 static const char * TAG = "self_test";
 

--- a/main/self_test/self_test.c
+++ b/main/self_test/self_test.c
@@ -147,23 +147,22 @@ void self_test(void * pvParameters)
         default:
     }
 
+    uint8_t result = VCORE_init(GLOBAL_STATE);
+    VCORE_set_voltage(nvs_config_get_u16(NVS_CONFIG_ASIC_VOLTAGE, CONFIG_ASIC_VOLTAGE) / 1000.0, GLOBAL_STATE);
+
     // VCore regulator testing
     switch (GLOBAL_STATE->device_model) {
         case DEVICE_MAX:
         case DEVICE_ULTRA:
         case DEVICE_SUPRA:
-            if(GLOBAL_STATE->board_version != 402){
-                if(!DS4432U_test()){
+            if (GLOBAL_STATE->board_version != 402){
+                if(!DS4432U_test()) {
                     ESP_LOGE(TAG, "DS4432 test failed!");
                     display_msg("DS4432U:FAIL", GLOBAL_STATE);
                     return;
                 }
-            }else{
-                
-                uint8_t result = VCORE_init(GLOBAL_STATE);
-                VCORE_set_voltage(nvs_config_get_u16(NVS_CONFIG_ASIC_VOLTAGE, CONFIG_ASIC_VOLTAGE) / 1000.0, GLOBAL_STATE);
-
-                if(result != 0){
+            } else {
+                if (result != 0) {
                     ESP_LOGE(TAG, "TPS546 test failed!");
                     display_msg("TPS546:FAIL", GLOBAL_STATE);
                     return;
@@ -171,11 +170,7 @@ void self_test(void * pvParameters)
             }
             break;
         case DEVICE_GAMMA:
-
-                uint8_t result = VCORE_init(GLOBAL_STATE);
-                VCORE_set_voltage(nvs_config_get_u16(NVS_CONFIG_ASIC_VOLTAGE, CONFIG_ASIC_VOLTAGE) / 1000.0, GLOBAL_STATE);
-
-                if(result != 0){
+                if (result != 0) {
                     ESP_LOGE(TAG, "TPS546 test failed!");
                     display_msg("TPS546:FAIL", GLOBAL_STATE);
                     return;

--- a/main/self_test/self_test.c
+++ b/main/self_test/self_test.c
@@ -39,7 +39,6 @@ static void display_msg(char * msg, GlobalState * GLOBAL_STATE) {
 }
 
 static void display_end_screen(GlobalState * GLOBAL_STATE) {
-    SystemModule * module = &GLOBAL_STATE->SYSTEM_MODULE;
 
     switch (GLOBAL_STATE->device_model) {
         case DEVICE_MAX:
@@ -294,13 +293,13 @@ void self_test(void * pvParameters)
         case DEVICE_SUPRA:
             if(GLOBAL_STATE->board_version != 402){
                 if (!INA260_power_consumption_pass(POWER_CONSUMPTION_TARGET_SUB_402, POWER_CONSUMPTION_MARGIN)) {
-                    ESP_LOGE(TAG, "INA260 Power Draw Failed, target %f", POWER_CONSUMPTION_TARGET_SUB_402);
+                    ESP_LOGE(TAG, "INA260 Power Draw Failed, target %.2f", (float)POWER_CONSUMPTION_TARGET_SUB_402);
                     display_msg("POWER:   FAIL", GLOBAL_STATE);
                     return;
                 }
             } else {
                 if (!TPS546_power_consumption_pass(POWER_CONSUMPTION_TARGET_402, POWER_CONSUMPTION_MARGIN)) {
-                    ESP_LOGE(TAG, "TPS546 Power Draw Failed, target %f", POWER_CONSUMPTION_TARGET_402);
+                    ESP_LOGE(TAG, "TPS546 Power Draw Failed, target %.2f", (float)POWER_CONSUMPTION_TARGET_402);
                     display_msg("POWER:   FAIL", GLOBAL_STATE);
                     return;
                 }
@@ -308,7 +307,7 @@ void self_test(void * pvParameters)
             break;
         case DEVICE_GAMMA:
                 if (!TPS546_power_consumption_pass(POWER_CONSUMPTION_TARGET_GAMMA, POWER_CONSUMPTION_MARGIN)) {
-                    ESP_LOGE(TAG, "TPS546 Power Draw Failed, target %f", POWER_CONSUMPTION_TARGET_GAMMA);
+                    ESP_LOGE(TAG, "TPS546 Power Draw Failed, target %.2f", (float)POWER_CONSUMPTION_TARGET_GAMMA);
                     display_msg("POWER:   FAIL", GLOBAL_STATE);
                     return;
                 }

--- a/main/self_test/self_test.c
+++ b/main/self_test/self_test.c
@@ -178,16 +178,16 @@ void self_test(void * pvParameters)
         case DEVICE_MAX:
         case DEVICE_ULTRA:
         case DEVICE_SUPRA:
-            if (GLOBAL_STATE->board_version != 402){
-                if(!DS4432U_test()) {
-                    ESP_LOGE(TAG, "DS4432 test failed!");
-                    display_msg("DS4432U:FAIL", GLOBAL_STATE);
-                    return;
-                }
-            } else {
+            if (GLOBAL_STATE->board_version >= 402 && GLOBAL_STATE->board_version <= 499){
                 if (result != 0) {
                     ESP_LOGE(TAG, "TPS546 test failed!");
                     display_msg("TPS546:FAIL", GLOBAL_STATE);
+                    return;
+                }
+            } else {
+                if(!DS4432U_test()) {
+                    ESP_LOGE(TAG, "DS4432 test failed!");
+                    display_msg("DS4432U:FAIL", GLOBAL_STATE);
                     return;
                 }
             }
@@ -291,15 +291,15 @@ void self_test(void * pvParameters)
         case DEVICE_MAX:
         case DEVICE_ULTRA:
         case DEVICE_SUPRA:
-            if(GLOBAL_STATE->board_version != 402){
-                if (!INA260_power_consumption_pass(POWER_CONSUMPTION_TARGET_SUB_402, POWER_CONSUMPTION_MARGIN)) {
-                    ESP_LOGE(TAG, "INA260 Power Draw Failed, target %.2f", (float)POWER_CONSUMPTION_TARGET_SUB_402);
+            if(GLOBAL_STATE->board_version >= 402 && GLOBAL_STATE->board_version <= 499){
+                if (!TPS546_power_consumption_pass(POWER_CONSUMPTION_TARGET_402, POWER_CONSUMPTION_MARGIN)) {
+                    ESP_LOGE(TAG, "TPS546 Power Draw Failed, target %.2f", (float)POWER_CONSUMPTION_TARGET_402);
                     display_msg("POWER:   FAIL", GLOBAL_STATE);
                     return;
                 }
             } else {
-                if (!TPS546_power_consumption_pass(POWER_CONSUMPTION_TARGET_402, POWER_CONSUMPTION_MARGIN)) {
-                    ESP_LOGE(TAG, "TPS546 Power Draw Failed, target %.2f", (float)POWER_CONSUMPTION_TARGET_402);
+                if (!INA260_power_consumption_pass(POWER_CONSUMPTION_TARGET_SUB_402, POWER_CONSUMPTION_MARGIN)) {
+                    ESP_LOGE(TAG, "INA260 Power Draw Failed, target %.2f", (float)POWER_CONSUMPTION_TARGET_SUB_402);
                     display_msg("POWER:   FAIL", GLOBAL_STATE);
                     return;
                 }

--- a/main/tasks/power_management_task.c
+++ b/main/tasks/power_management_task.c
@@ -94,7 +94,7 @@ void POWER_MANAGEMENT_task(void * pvParameters)
         case DEVICE_MAX:
         case DEVICE_ULTRA:
         case DEVICE_SUPRA:
-			if (GLOBAL_STATE->board_version != 402) {
+			if (GLOBAL_STATE->board_version < 402 || GLOBAL_STATE->board_version > 499) {
                 // Configure GPIO12 as input(barrel jack) 1 is plugged in
                 gpio_config_t barrel_jack_conf = {
                     .pin_bit_mask = (1ULL << GPIO_NUM_12),
@@ -128,7 +128,7 @@ void POWER_MANAGEMENT_task(void * pvParameters)
             case DEVICE_MAX:
             case DEVICE_ULTRA:
             case DEVICE_SUPRA:
-				if (GLOBAL_STATE->board_version == 402) {
+				if (GLOBAL_STATE->board_version >= 402 && GLOBAL_STATE->board_version <= 499) {
                     power_management->voltage = TPS546_get_vin() * 1000;
                     power_management->current = TPS546_get_iout() * 1000;
                     // calculate regulator power (in milliwatts)
@@ -177,7 +177,7 @@ void POWER_MANAGEMENT_task(void * pvParameters)
             case DEVICE_ULTRA:
             case DEVICE_SUPRA:
                 
-                if (GLOBAL_STATE->board_version == 402) {
+                if (GLOBAL_STATE->board_version >= 402 && GLOBAL_STATE->board_version <= 499) {
                     power_management->chip_temp_avg = GLOBAL_STATE->ASIC_initalized ? EMC2101_get_external_temp() : -1;
                     power_management->vr_temp = (float)TPS546_get_temperature();
                 } else {
@@ -196,7 +196,7 @@ void POWER_MANAGEMENT_task(void * pvParameters)
                     ESP_LOGE(TAG, "OVERHEAT! VR: %fC ASIC %fC", power_management->vr_temp, power_management->chip_temp_avg );
 
                     EMC2101_set_fan_speed(1);
-                    if (GLOBAL_STATE->board_version == 402) {
+                    if (GLOBAL_STATE->board_version >= 402 && GLOBAL_STATE->board_version <= 499) {
                         // Turn off core voltage
                         VCORE_set_voltage(0.0, GLOBAL_STATE);
                     } else if (power_management->HAS_POWER_EN) {

--- a/main/vcore.c
+++ b/main/vcore.c
@@ -27,7 +27,7 @@ uint8_t VCORE_init(GlobalState * global_state) {
         case DEVICE_MAX:
         case DEVICE_ULTRA:
         case DEVICE_SUPRA:
-            if (global_state->board_version == 402) {
+            if (global_state->board_version >= 402 && global_state->board_version <= 499) {
                 result = TPS546_init();
             }
             break;
@@ -75,7 +75,7 @@ bool VCORE_set_voltage(float core_voltage, GlobalState * global_state)
         case DEVICE_MAX:
         case DEVICE_ULTRA:
         case DEVICE_SUPRA:
-            if (global_state->board_version == 402) {
+            if (global_state->board_version >= 402 && global_state->board_version <= 499) {
                 ESP_LOGI(TAG, "Set ASIC voltage = %.3fV", core_voltage);
                 TPS546_set_vout(core_voltage * (float)global_state->voltage_domain);
             } else {


### PR DESCRIPTION
selftest was no longer working on older TPS40305-based devices. this should fix that.