### PR TITLE
Version mask now based on stratum msg

### DIFF
--- a/components/asic/bm1366.c
+++ b/components/asic/bm1366.c
@@ -126,7 +126,7 @@ static void _set_chip_address(uint8_t chipAddr)
     _send_BM1366((TYPE_CMD | GROUP_SINGLE | CMD_SETADDRESS), read_address, 2, BM1366_SERIALTX_DEBUG);
 }
 
-static void BM1366_set_version_mask(uint32_t version_mask) 
+void BM1366_set_version_mask(uint32_t version_mask) 
 {
     int versions_to_roll = version_mask >> 13;
     uint8_t version_byte0 = (versions_to_roll >> 8);

--- a/components/asic/bm1366.c
+++ b/components/asic/bm1366.c
@@ -126,7 +126,7 @@ static void _set_chip_address(uint8_t chipAddr)
     _send_BM1366((TYPE_CMD | GROUP_SINGLE | CMD_SETADDRESS), read_address, 2, BM1366_SERIALTX_DEBUG);
 }
 
-static void _set_chip_version_mask(uint32_t version_mask) 
+static void BM1366_set_version_mask(uint32_t version_mask) 
 {
     int versions_to_roll = version_mask >> 13;
     uint8_t version_byte0 = (versions_to_roll >> 8);
@@ -408,12 +408,12 @@ static void do_frequency_ramp_up()
     _send_simple(init793, 11);
 }
 
-static uint8_t _send_init(uint64_t frequency, uint16_t asic_count, uint32_t version_mask)
+static uint8_t _send_init(uint64_t frequency, uint16_t asic_count)
 {
 
     // set version mask
     for (int i = 0; i < 3; i++) {
-        _set_chip_version_mask(version_mask);
+        BM1366_set_version_mask(STRATUM_DEFAULT_VERSION_MASK);
     }
 
     // read register 00 on all chips
@@ -524,7 +524,7 @@ static void _send_read_address(void)
     _send_BM1366((TYPE_CMD | GROUP_ALL | CMD_READ), read_address, 2, BM1366_SERIALTX_DEBUG);
 }
 
-uint8_t BM1366_init(uint64_t frequency, uint16_t asic_count, uint32_t version_mask)
+uint8_t BM1366_init(uint64_t frequency, uint16_t asic_count)
 {
     ESP_LOGI(TAG, "Initializing BM1366");
 
@@ -536,7 +536,7 @@ uint8_t BM1366_init(uint64_t frequency, uint16_t asic_count, uint32_t version_ma
     // reset the bm1366
     _reset();
 
-    return _send_init(frequency, asic_count, version_mask);
+    return _send_init(frequency, asic_count);
 }
 
 // Baud formula = 25M/((denominator+1)*8)

--- a/components/asic/bm1368.c
+++ b/components/asic/bm1368.c
@@ -114,7 +114,7 @@ static void _set_chip_version_mask(uint32_t version_mask)
     uint8_t version_byte0 = (versions_to_roll >> 8);
     uint8_t version_byte1 = (versions_to_roll & 0xFF); 
     uint8_t version_cmd[] = {0x00, 0xA4, 0x90, 0x00, version_byte0, version_byte1};
-    _send_BM1368(TYPE_CMD | GROUP_ALL | CMD_WRITE, version_cmd, 6, false);
+    _send_BM1368(TYPE_CMD | GROUP_ALL | CMD_WRITE, version_cmd, 6, BM1368_SERIALTX_DEBUG);
 }
 
 static void _reset(void)
@@ -234,7 +234,7 @@ static void do_frequency_ramp_up(float target_frequency) {
     do_frequency_transition(target_frequency);
 }
 
-uint8_t BM1368_init(uint64_t frequency, uint16_t asic_count)
+uint8_t BM1368_init(uint64_t frequency, uint16_t asic_count, uint32_t version_mask)
 {
     ESP_LOGI(TAG, "Initializing BM1368");
 
@@ -244,9 +244,10 @@ uint8_t BM1368_init(uint64_t frequency, uint16_t asic_count)
     gpio_set_direction(BM1368_RST_PIN, GPIO_MODE_OUTPUT);
 
     _reset();
-    uint_32_t version_mask_default = 0x1fffe000;
+
+    // set version mask
     for (int i = 0; i < 4; i++) {
-        _set_chip_version_mask(version_mask_default);
+        _set_chip_version_mask(version_mask);
     }
 
     int chip_counter = count_asic_chips();
@@ -295,7 +296,7 @@ uint8_t BM1368_init(uint64_t frequency, uint16_t asic_count)
     do_frequency_ramp_up((float)frequency);
 
     _send_BM1368(TYPE_CMD | GROUP_ALL | CMD_WRITE, (uint8_t[]){0x00, 0x10, 0x00, 0x00, 0x15, 0xa4}, 6, false);
-    _set_chip_version_mask(version_mask_default)
+    _set_chip_version_mask(version_mask);
 
     ESP_LOGI(TAG, "%i chip(s) detected on the chain, expected %i", chip_counter, asic_count);
     return chip_counter;

--- a/components/asic/bm1368.c
+++ b/components/asic/bm1368.c
@@ -113,8 +113,8 @@ static void _set_chip_version_mask(uint32_t version_mask)
     int versions_to_roll = version_mask >> 13;
     uint8_t version_byte0 = (versions_to_roll >> 8);
     uint8_t version_byte1 = (versions_to_roll & 0xFF); 
-    uint8_t init_cmd[] = {0x00, 0xA4, 0x90, 0x00, version_byte0, version_byte1};
-    _send_BM1368(TYPE_CMD | GROUP_ALL | CMD_WRITE, init_cmd, 6, false);
+    uint8_t version_cmd[] = {0x00, 0xA4, 0x90, 0x00, version_byte0, version_byte1};
+    _send_BM1368(TYPE_CMD | GROUP_ALL | CMD_WRITE, version_cmd, 6, false);
 }
 
 static void _reset(void)

--- a/components/asic/bm1368.c
+++ b/components/asic/bm1368.c
@@ -108,7 +108,7 @@ static void _set_chip_address(uint8_t chipAddr)
     _send_BM1368((TYPE_CMD | GROUP_SINGLE | CMD_SETADDRESS), read_address, 2, BM1368_SERIALTX_DEBUG);
 }
 
-static void _set_chip_version_mask(uint32_t version_mask) 
+static void BM1368_set_version_mask(uint32_t version_mask) 
 {
     int versions_to_roll = version_mask >> 13;
     uint8_t version_byte0 = (versions_to_roll >> 8);
@@ -234,7 +234,7 @@ static void do_frequency_ramp_up(float target_frequency) {
     do_frequency_transition(target_frequency);
 }
 
-uint8_t BM1368_init(uint64_t frequency, uint16_t asic_count, uint32_t version_mask)
+uint8_t BM1368_init(uint64_t frequency, uint16_t asic_count)
 {
     ESP_LOGI(TAG, "Initializing BM1368");
 
@@ -247,7 +247,7 @@ uint8_t BM1368_init(uint64_t frequency, uint16_t asic_count, uint32_t version_ma
 
     // set version mask
     for (int i = 0; i < 4; i++) {
-        _set_chip_version_mask(version_mask);
+        BM1368_set_version_mask(STRATUM_DEFAULT_VERSION_MASK);
     }
 
     int chip_counter = count_asic_chips();
@@ -296,7 +296,7 @@ uint8_t BM1368_init(uint64_t frequency, uint16_t asic_count, uint32_t version_ma
     do_frequency_ramp_up((float)frequency);
 
     _send_BM1368(TYPE_CMD | GROUP_ALL | CMD_WRITE, (uint8_t[]){0x00, 0x10, 0x00, 0x00, 0x15, 0xa4}, 6, false);
-    _set_chip_version_mask(version_mask);
+    BM1368_set_version_mask(STRATUM_DEFAULT_VERSION_MASK);
 
     ESP_LOGI(TAG, "%i chip(s) detected on the chain, expected %i", chip_counter, asic_count);
     return chip_counter;

--- a/components/asic/bm1368.c
+++ b/components/asic/bm1368.c
@@ -108,6 +108,15 @@ static void _set_chip_address(uint8_t chipAddr)
     _send_BM1368((TYPE_CMD | GROUP_SINGLE | CMD_SETADDRESS), read_address, 2, BM1368_SERIALTX_DEBUG);
 }
 
+static void _set_chip_version_mask(uint32_t version_mask) 
+{
+    int versions_to_roll = version_mask >> 13;
+    uint8_t version_byte0 = (versions_to_roll >> 8);
+    uint8_t version_byte1 = (versions_to_roll & 0xFF); 
+    uint8_t init_cmd[] = {0x00, 0xA4, 0x90, 0x00, version_byte0, version_byte1};
+    _send_BM1368(TYPE_CMD | GROUP_ALL | CMD_WRITE, init_cmd, 6, false);
+}
+
 static void _reset(void)
 {
     gpio_set_level(BM1368_RST_PIN, 0);
@@ -218,6 +227,8 @@ static int count_asic_chips(void) {
     return chip_counter;
 }
 
+
+
 static void do_frequency_ramp_up(float target_frequency) {
     ESP_LOGI(TAG, "Ramping up frequency from %.2f MHz to %.2f MHz", current_frequency, target_frequency);
     do_frequency_transition(target_frequency);
@@ -233,10 +244,9 @@ uint8_t BM1368_init(uint64_t frequency, uint16_t asic_count)
     gpio_set_direction(BM1368_RST_PIN, GPIO_MODE_OUTPUT);
 
     _reset();
-
-    uint8_t init_cmd[] = {0x00, 0xA4, 0x90, 0x00, 0xFF, 0xFF};
+    uint_32_t version_mask_default = 0x1fffe000;
     for (int i = 0; i < 4; i++) {
-        _send_BM1368(TYPE_CMD | GROUP_ALL | CMD_WRITE, init_cmd, 6, false);
+        _set_chip_version_mask(version_mask_default);
     }
 
     int chip_counter = count_asic_chips();
@@ -285,7 +295,7 @@ uint8_t BM1368_init(uint64_t frequency, uint16_t asic_count)
     do_frequency_ramp_up((float)frequency);
 
     _send_BM1368(TYPE_CMD | GROUP_ALL | CMD_WRITE, (uint8_t[]){0x00, 0x10, 0x00, 0x00, 0x15, 0xa4}, 6, false);
-    _send_BM1368(TYPE_CMD | GROUP_ALL | CMD_WRITE, (uint8_t[]){0x00, 0xA4, 0x90, 0x00, 0xFF, 0xFF}, 6, false);
+    _set_chip_version_mask(version_mask_default)
 
     ESP_LOGI(TAG, "%i chip(s) detected on the chain, expected %i", chip_counter, asic_count);
     return chip_counter;

--- a/components/asic/bm1368.c
+++ b/components/asic/bm1368.c
@@ -108,7 +108,7 @@ static void _set_chip_address(uint8_t chipAddr)
     _send_BM1368((TYPE_CMD | GROUP_SINGLE | CMD_SETADDRESS), read_address, 2, BM1368_SERIALTX_DEBUG);
 }
 
-static void BM1368_set_version_mask(uint32_t version_mask) 
+void BM1368_set_version_mask(uint32_t version_mask) 
 {
     int versions_to_roll = version_mask >> 13;
     uint8_t version_byte0 = (versions_to_roll >> 8);

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -128,7 +128,7 @@ static void _set_chip_address(uint8_t chipAddr)
     _send_BM1370((TYPE_CMD | GROUP_SINGLE | CMD_SETADDRESS), read_address, 2, BM1370_SERIALTX_DEBUG);
 }
 
-static void BM1370_set_version_mask(uint32_t version_mask) 
+void BM1370_set_version_mask(uint32_t version_mask) 
 {
     int versions_to_roll = version_mask >> 13;
     uint8_t version_byte0 = (versions_to_roll >> 8);

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -128,7 +128,7 @@ static void _set_chip_address(uint8_t chipAddr)
     _send_BM1370((TYPE_CMD | GROUP_SINGLE | CMD_SETADDRESS), read_address, 2, BM1370_SERIALTX_DEBUG);
 }
 
-static void _set_chip_version_mask(uint32_t version_mask) 
+static void BM1370_set_version_mask(uint32_t version_mask) 
 {
     int versions_to_roll = version_mask >> 13;
     uint8_t version_byte0 = (versions_to_roll >> 8);
@@ -204,11 +204,11 @@ static void do_frequency_ramp_up(float target_frequency) {
     }
 }
 
-static uint8_t _send_init(uint64_t frequency, uint16_t asic_count, uint32_t version_mask)
+static uint8_t _send_init(uint64_t frequency, uint16_t asic_count)
 {
     // set version mask
     for (int i = 0; i < 3; i++) {
-        _set_chip_version_mask(version_mask);
+        BM1370_set_version_mask(STRATUM_DEFAULT_VERSION_MASK);
     }
 
     //read register 00 on all chips (should respond AA 55 13 68 00 00 00 00 00 00 0F)
@@ -226,7 +226,7 @@ static uint8_t _send_init(uint64_t frequency, uint16_t asic_count, uint32_t vers
     ESP_LOGI(TAG, "%i chip(s) detected on the chain, expected %i", chip_counter, asic_count);
 
     // set version mask
-    _set_chip_version_mask(version_mask);
+    BM1370_set_version_mask(STRATUM_DEFAULT_VERSION_MASK);
 
     //Reg_A8
     unsigned char init5[11] = {0x55, 0xAA, 0x51, 0x09, 0x00, 0xA8, 0x00, 0x07, 0x00, 0x00, 0x03};
@@ -335,7 +335,7 @@ static void _send_read_address(void)
     _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_READ), read_address, 2, BM1370_SERIALTX_DEBUG);
 }
 
-uint8_t BM1370_init(uint64_t frequency, uint16_t asic_count, uint32_t version_mask)
+uint8_t BM1370_init(uint64_t frequency, uint16_t asic_count)
 {
     ESP_LOGI(TAG, "Initializing BM1370");
 
@@ -347,7 +347,7 @@ uint8_t BM1370_init(uint64_t frequency, uint16_t asic_count, uint32_t version_ma
     // reset the bm1370
     _reset();
 
-    return _send_init(frequency, asic_count,version_mask);
+    return _send_init(frequency, asic_count);
 }
 
 // Baud formula = 25M/((denominator+1)*8)

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -128,6 +128,15 @@ static void _set_chip_address(uint8_t chipAddr)
     _send_BM1370((TYPE_CMD | GROUP_SINGLE | CMD_SETADDRESS), read_address, 2, BM1370_SERIALTX_DEBUG);
 }
 
+static void _set_chip_version_mask(uint32_t version_mask) 
+{
+    int versions_to_roll = version_mask >> 13;
+    uint8_t version_byte0 = (versions_to_roll >> 8);
+    uint8_t version_byte1 = (versions_to_roll & 0xFF); 
+    uint8_t version_cmd[] = {0x00, 0xA4, 0x90, 0x00, version_byte0, version_byte1};
+    _send_BM1370(TYPE_CMD | GROUP_ALL | CMD_WRITE, version_cmd, 6, BM1370_SERIALTX_DEBUG);
+}
+
 void BM1370_send_hash_frequency(int id, float target_freq, float max_diff) {
     uint8_t freqbuf[6] = {0x00, 0x08, 0x40, 0xA0, 0x02, 0x41};
     uint8_t postdiv_min = 255;
@@ -195,20 +204,12 @@ static void do_frequency_ramp_up(float target_frequency) {
     }
 }
 
-static uint8_t _send_init(uint64_t frequency, uint16_t asic_count)
+static uint8_t _send_init(uint64_t frequency, uint16_t asic_count, uint32_t version_mask)
 {
-
-    //enable and set version rolling mask to 0xFFFF
-    unsigned char init0[11] = {0x55, 0xAA, 0x51, 0x09, 0x00, 0xA4, 0x90, 0x00, 0xFF, 0xFF, 0x1C};
-    _send_simple(init0, 11);
-
-    //enable and set version rolling mask to 0xFFFF (again)
-    unsigned char init1[11] = {0x55, 0xAA, 0x51, 0x09, 0x00, 0xA4, 0x90, 0x00, 0xFF, 0xFF, 0x1C};
-    _send_simple(init1, 11);
-
-    //enable and set version rolling mask to 0xFFFF (again)
-    unsigned char init2[11] = {0x55, 0xAA, 0x51, 0x09, 0x00, 0xA4, 0x90, 0x00, 0xFF, 0xFF, 0x1C};
-    _send_simple(init2, 11);
+    // set version mask
+    for (int i = 0; i < 3; i++) {
+        _set_chip_version_mask(version_mask);
+    }
 
     //read register 00 on all chips (should respond AA 55 13 68 00 00 00 00 00 00 0F)
     unsigned char init3[7] = {0x55, 0xAA, 0x52, 0x05, 0x00, 0x00, 0x0A};
@@ -224,9 +225,8 @@ static uint8_t _send_init(uint64_t frequency, uint16_t asic_count)
     }
     ESP_LOGI(TAG, "%i chip(s) detected on the chain, expected %i", chip_counter, asic_count);
 
-    //enable and set version rolling mask to 0xFFFF (again)
-    unsigned char init4[11] = {0x55, 0xAA, 0x51, 0x09, 0x00, 0xA4, 0x90, 0x00, 0xFF, 0xFF, 0x1C};
-    _send_simple(init4, 11);
+    // set version mask
+    _set_chip_version_mask(version_mask);
 
     //Reg_A8
     unsigned char init5[11] = {0x55, 0xAA, 0x51, 0x09, 0x00, 0xA8, 0x00, 0x07, 0x00, 0x00, 0x03};
@@ -335,7 +335,7 @@ static void _send_read_address(void)
     _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_READ), read_address, 2, BM1370_SERIALTX_DEBUG);
 }
 
-uint8_t BM1370_init(uint64_t frequency, uint16_t asic_count)
+uint8_t BM1370_init(uint64_t frequency, uint16_t asic_count, uint32_t version_mask)
 {
     ESP_LOGI(TAG, "Initializing BM1370");
 
@@ -347,7 +347,7 @@ uint8_t BM1370_init(uint64_t frequency, uint16_t asic_count)
     // reset the bm1370
     _reset();
 
-    return _send_init(frequency, asic_count);
+    return _send_init(frequency, asic_count,version_mask);
 }
 
 // Baud formula = 25M/((denominator+1)*8)

--- a/components/asic/bm1397.c
+++ b/components/asic/bm1397.c
@@ -283,7 +283,7 @@ static void _reset(void)
     vTaskDelay(100 / portTICK_PERIOD_MS);
 }
 
-uint8_t BM1397_init(uint64_t frequency, uint16_t asic_count)
+uint8_t BM1397_init(uint64_t frequency, uint16_t asic_count, uint32_t version_mask)
 {
     ESP_LOGI(TAG, "Initializing BM1397");
 

--- a/components/asic/bm1397.c
+++ b/components/asic/bm1397.c
@@ -127,6 +127,10 @@ static void _set_chip_address(uint8_t chipAddr)
     _send_BM1397((TYPE_CMD | GROUP_SINGLE | CMD_SETADDRESS), read_address, 2, BM1937_SERIALTX_DEBUG);
 }
 
+static void BM1397_set_version_mask(uint32_t version_mask) {
+    // placeholder
+}
+
 // borrowed from cgminer driver-gekko.c calc_gsf_freq()
 void BM1397_send_hash_frequency(float frequency)
 {
@@ -283,7 +287,7 @@ static void _reset(void)
     vTaskDelay(100 / portTICK_PERIOD_MS);
 }
 
-uint8_t BM1397_init(uint64_t frequency, uint16_t asic_count, uint32_t version_mask)
+uint8_t BM1397_init(uint64_t frequency, uint16_t asic_count)
 {
     ESP_LOGI(TAG, "Initializing BM1397");
 

--- a/components/asic/bm1397.c
+++ b/components/asic/bm1397.c
@@ -127,7 +127,7 @@ static void _set_chip_address(uint8_t chipAddr)
     _send_BM1397((TYPE_CMD | GROUP_SINGLE | CMD_SETADDRESS), read_address, 2, BM1937_SERIALTX_DEBUG);
 }
 
-static void BM1397_set_version_mask(uint32_t version_mask) {
+void BM1397_set_version_mask(uint32_t version_mask) {
     // placeholder
 }
 

--- a/components/asic/include/bm1366.h
+++ b/components/asic/include/bm1366.h
@@ -40,6 +40,7 @@ uint8_t BM1366_init(uint64_t frequency, uint16_t asic_count);
 void BM1366_send_init(void);
 void BM1366_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1366_set_job_difficulty_mask(int);
+void BM1366_set_version_mask(uint32_t version_mask);
 int BM1366_set_max_baud(void);
 int BM1366_set_default_baud(void);
 void BM1366_send_hash_frequency(float frequency);

--- a/components/asic/include/bm1366.h
+++ b/components/asic/include/bm1366.h
@@ -35,7 +35,7 @@ typedef struct __attribute__((__packed__))
     uint8_t version[4];
 } BM1366_job;
 
-uint8_t BM1366_init(uint64_t frequency, uint16_t asic_count);
+uint8_t BM1366_init(uint64_t frequency, uint16_t asic_count, uint32_t version_mask);
 
 void BM1366_send_init(void);
 void BM1366_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);

--- a/components/asic/include/bm1366.h
+++ b/components/asic/include/bm1366.h
@@ -35,7 +35,7 @@ typedef struct __attribute__((__packed__))
     uint8_t version[4];
 } BM1366_job;
 
-uint8_t BM1366_init(uint64_t frequency, uint16_t asic_count, uint32_t version_mask);
+uint8_t BM1366_init(uint64_t frequency, uint16_t asic_count);
 
 void BM1366_send_init(void);
 void BM1366_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);

--- a/components/asic/include/bm1368.h
+++ b/components/asic/include/bm1368.h
@@ -40,6 +40,7 @@ uint8_t BM1368_init(uint64_t frequency, uint16_t asic_count);
 uint8_t BM1368_send_init(void);
 void BM1368_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1368_set_job_difficulty_mask(int);
+void BM1368_set_version_mask(uint32_t version_mask);
 int BM1368_set_max_baud(void);
 int BM1368_set_default_baud(void);
 bool BM1368_send_hash_frequency(float frequency);

--- a/components/asic/include/bm1368.h
+++ b/components/asic/include/bm1368.h
@@ -35,7 +35,7 @@ typedef struct __attribute__((__packed__))
     uint8_t version[4];
 } BM1368_job;
 
-uint8_t BM1368_init(uint64_t frequency, uint16_t asic_count, uint32_t version_mask);
+uint8_t BM1368_init(uint64_t frequency, uint16_t asic_count);
 
 uint8_t BM1368_send_init(void);
 void BM1368_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);

--- a/components/asic/include/bm1368.h
+++ b/components/asic/include/bm1368.h
@@ -35,7 +35,7 @@ typedef struct __attribute__((__packed__))
     uint8_t version[4];
 } BM1368_job;
 
-uint8_t BM1368_init(uint64_t frequency, uint16_t asic_count);
+uint8_t BM1368_init(uint64_t frequency, uint16_t asic_count, uint32_t version_mask);
 
 uint8_t BM1368_send_init(void);
 void BM1368_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);

--- a/components/asic/include/bm1370.h
+++ b/components/asic/include/bm1370.h
@@ -41,6 +41,7 @@ uint8_t BM1370_init(uint64_t frequency, uint16_t asic_count);
 uint8_t BM1370_send_init(void);
 void BM1370_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1370_set_job_difficulty_mask(int);
+void BM1370_set_version_mask(uint32_t version_mask);
 int BM1370_set_max_baud(void);
 int BM1370_set_default_baud(void);
 void BM1370_send_hash_frequency(int, float, float);

--- a/components/asic/include/bm1370.h
+++ b/components/asic/include/bm1370.h
@@ -36,7 +36,7 @@ typedef struct __attribute__((__packed__))
     uint8_t version[4];
 } BM1370_job;
 
-uint8_t BM1370_init(uint64_t frequency, uint16_t asic_count);
+uint8_t BM1370_init(uint64_t frequency, uint16_t asic_count, uint32_t version_mask);
 
 uint8_t BM1370_send_init(void);
 void BM1370_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);

--- a/components/asic/include/bm1370.h
+++ b/components/asic/include/bm1370.h
@@ -36,7 +36,7 @@ typedef struct __attribute__((__packed__))
     uint8_t version[4];
 } BM1370_job;
 
-uint8_t BM1370_init(uint64_t frequency, uint16_t asic_count, uint32_t version_mask);
+uint8_t BM1370_init(uint64_t frequency, uint16_t asic_count);
 
 uint8_t BM1370_send_init(void);
 void BM1370_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);

--- a/components/asic/include/bm1397.h
+++ b/components/asic/include/bm1397.h
@@ -53,6 +53,7 @@ uint8_t BM1397_init(uint64_t frequency, uint16_t asic_count);
 
 void BM1397_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1397_set_job_difficulty_mask(int);
+void BM1397_set_version_mask(uint32_t version_mask);
 int BM1397_set_max_baud(void);
 int BM1397_set_default_baud(void);
 void BM1397_send_hash_frequency(float frequency);

--- a/components/asic/include/bm1397.h
+++ b/components/asic/include/bm1397.h
@@ -49,7 +49,7 @@ typedef struct __attribute__((__packed__))
     uint8_t midstate3[32];
 } job_packet;
 
-uint8_t BM1397_init(uint64_t frequency, uint16_t asic_count, uint32_t version_mask);
+uint8_t BM1397_init(uint64_t frequency, uint16_t asic_count);
 
 void BM1397_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1397_set_job_difficulty_mask(int);

--- a/components/asic/include/bm1397.h
+++ b/components/asic/include/bm1397.h
@@ -49,7 +49,7 @@ typedef struct __attribute__((__packed__))
     uint8_t midstate3[32];
 } job_packet;
 
-uint8_t BM1397_init(uint64_t frequency, uint16_t asic_count);
+uint8_t BM1397_init(uint64_t frequency, uint16_t asic_count, uint32_t version_mask);
 
 void BM1397_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1397_set_job_difficulty_mask(int);

--- a/components/stratum/include/utils.h
+++ b/components/stratum/include/utils.h
@@ -34,4 +34,6 @@ void prettyHex(unsigned char *buf, int len);
 
 uint32_t flip32(uint32_t val);
 
+#define STRATUM_DEFAULT_VERSION_MASK 0x1fffe000
+
 #endif // STRATUM_UTILS_H

--- a/main/global_state.h
+++ b/main/global_state.h
@@ -39,7 +39,7 @@ typedef enum
 
 typedef struct
 {
-    uint8_t (*init_fn)(uint64_t, uint16_t, uint32_t);
+    uint8_t (*init_fn)(uint64_t, uint16_t);
     task_result * (*receive_result_fn)(void * GLOBAL_STATE);
     int (*set_max_baud_fn)(void);
     void (*set_difficulty_mask_fn)(int);

--- a/main/global_state.h
+++ b/main/global_state.h
@@ -44,6 +44,7 @@ typedef struct
     int (*set_max_baud_fn)(void);
     void (*set_difficulty_mask_fn)(int);
     void (*send_work_fn)(void * GLOBAL_STATE, bm_job * next_bm_job);
+    void (*set_version_mask)(uint32_t);
 } AsicFunctions;
 
 typedef struct

--- a/main/global_state.h
+++ b/main/global_state.h
@@ -39,7 +39,7 @@ typedef enum
 
 typedef struct
 {
-    uint8_t (*init_fn)(uint64_t, uint16_t);
+    uint8_t (*init_fn)(uint64_t, uint16_t, uint32_t);
     task_result * (*receive_result_fn)(void * GLOBAL_STATE);
     int (*set_max_baud_fn)(void);
     void (*set_difficulty_mask_fn)(int);

--- a/main/global_state.h
+++ b/main/global_state.h
@@ -105,7 +105,7 @@ typedef struct
 
     uint32_t stratum_difficulty;
     uint32_t version_mask;
-    bool version_mask_given;
+    bool new_stratum_version_rolling_msg;
 
     int sock;
     bool ASIC_initalized;

--- a/main/global_state.h
+++ b/main/global_state.h
@@ -105,6 +105,7 @@ typedef struct
 
     uint32_t stratum_difficulty;
     uint32_t version_mask;
+    bool version_mask_given;
 
     int sock;
     bool ASIC_initalized;

--- a/main/main.c
+++ b/main/main.c
@@ -196,14 +196,16 @@ void app_main(void)
         queue_init(&GLOBAL_STATE.stratum_queue);
         queue_init(&GLOBAL_STATE.ASIC_jobs_queue);
 
+        xTaskCreate(stratum_task, "stratum admin", 8192, (void *) &GLOBAL_STATE, 5, NULL);
+
+        // GLOBAL_STATE.version_mask comes from stratum_task 
         SERIAL_init();
-        (*GLOBAL_STATE.ASIC_functions.init_fn)(GLOBAL_STATE.POWER_MANAGEMENT_MODULE.frequency_value, GLOBAL_STATE.asic_count);
+        (*GLOBAL_STATE.ASIC_functions.init_fn)(GLOBAL_STATE.POWER_MANAGEMENT_MODULE.frequency_value, GLOBAL_STATE.asic_count,GLOBAL_STATE.version_mask);
         SERIAL_set_baud((*GLOBAL_STATE.ASIC_functions.set_max_baud_fn)());
         SERIAL_clear_buffer();
 
         GLOBAL_STATE.ASIC_initalized = true;
 
-        xTaskCreate(stratum_task, "stratum admin", 8192, (void *) &GLOBAL_STATE, 5, NULL);
         xTaskCreate(create_jobs_task, "stratum miner", 8192, (void *) &GLOBAL_STATE, 10, NULL);
         xTaskCreate(ASIC_task, "asic", 8192, (void *) &GLOBAL_STATE, 10, NULL);
         xTaskCreate(ASIC_result_task, "asic result", 8192, (void *) &GLOBAL_STATE, 15, NULL);

--- a/main/main.c
+++ b/main/main.c
@@ -191,6 +191,7 @@ void app_main(void)
 
     // set the startup_done flag
     GLOBAL_STATE.SYSTEM_MODULE.startup_done = true;
+    GLOBAL_STATE.version_mask_given = false;
 
     xTaskCreate(USER_INPUT_task, "user input", 8192, (void *) &GLOBAL_STATE, 5, NULL);
 
@@ -210,10 +211,6 @@ void app_main(void)
 
         xTaskCreate(stratum_task, "stratum admin", 8192, (void *) &GLOBAL_STATE, 5, NULL);
         xTaskCreate(create_jobs_task, "stratum miner", 8192, (void *) &GLOBAL_STATE, 10, NULL);
-
-        //set the version mask after talking to stratum
-        (*GLOBAL_STATE.ASIC_functions.set_version_mask)(GLOBAL_STATE.version_mask);
-
         xTaskCreate(ASIC_task, "asic", 8192, (void *) &GLOBAL_STATE, 10, NULL);
         xTaskCreate(ASIC_result_task, "asic result", 8192, (void *) &GLOBAL_STATE, 15, NULL);
     }

--- a/main/main.c
+++ b/main/main.c
@@ -207,7 +207,6 @@ void app_main(void)
         SERIAL_clear_buffer();
 
         GLOBAL_STATE.ASIC_initalized = true;
-        
 
         xTaskCreate(stratum_task, "stratum admin", 8192, (void *) &GLOBAL_STATE, 5, NULL);
         xTaskCreate(create_jobs_task, "stratum miner", 8192, (void *) &GLOBAL_STATE, 10, NULL);

--- a/main/main.c
+++ b/main/main.c
@@ -201,7 +201,7 @@ void app_main(void)
         queue_init(&GLOBAL_STATE.ASIC_jobs_queue);
 
         SERIAL_init();
-        (*GLOBAL_STATE.ASIC_functions.init_fn)(GLOBAL_STATE.POWER_MANAGEMENT_MODULE.frequency_value, GLOBAL_STATE.asic_count,(uint32_t)0x1fffe000);
+        (*GLOBAL_STATE.ASIC_functions.init_fn)(GLOBAL_STATE.POWER_MANAGEMENT_MODULE.frequency_value, GLOBAL_STATE.asic_count);
         SERIAL_set_baud((*GLOBAL_STATE.ASIC_functions.set_max_baud_fn)());
         SERIAL_clear_buffer();
 
@@ -212,7 +212,7 @@ void app_main(void)
         xTaskCreate(create_jobs_task, "stratum miner", 8192, (void *) &GLOBAL_STATE, 10, NULL);
 
         //set the version mask after talking to stratum
-        (*GLOBAL_STATE.ASIC_functions.set_version_mask)(GLOBAL_STATE.version_mask)
+        (*GLOBAL_STATE.ASIC_functions.set_version_mask)(GLOBAL_STATE.version_mask);
 
         xTaskCreate(ASIC_task, "asic", 8192, (void *) &GLOBAL_STATE, 10, NULL);
         xTaskCreate(ASIC_result_task, "asic result", 8192, (void *) &GLOBAL_STATE, 15, NULL);

--- a/main/main.c
+++ b/main/main.c
@@ -191,7 +191,7 @@ void app_main(void)
 
     // set the startup_done flag
     GLOBAL_STATE.SYSTEM_MODULE.startup_done = true;
-    GLOBAL_STATE.version_mask_given = false;
+    GLOBAL_STATE.new_stratum_version_rolling_msg = false;
 
     xTaskCreate(USER_INPUT_task, "user input", 8192, (void *) &GLOBAL_STATE, 5, NULL);
 

--- a/main/self_test/self_test.c
+++ b/main/self_test/self_test.c
@@ -204,7 +204,7 @@ void self_test(void * pvParameters)
 
 
     SERIAL_init();
-    uint8_t chips_detected = (GLOBAL_STATE->ASIC_functions.init_fn)(GLOBAL_STATE->POWER_MANAGEMENT_MODULE.frequency_value, GLOBAL_STATE->asic_count, (uint32_t)0x1fffe000);
+    uint8_t chips_detected = (GLOBAL_STATE->ASIC_functions.init_fn)(GLOBAL_STATE->POWER_MANAGEMENT_MODULE.frequency_value, GLOBAL_STATE->asic_count);
     ESP_LOGI(TAG, "%u chips detected, %u expected", chips_detected, GLOBAL_STATE->asic_count);
 
     int baud = (*GLOBAL_STATE->ASIC_functions.set_max_baud_fn)();

--- a/main/self_test/self_test.c
+++ b/main/self_test/self_test.c
@@ -204,7 +204,7 @@ void self_test(void * pvParameters)
 
 
     SERIAL_init();
-    uint8_t chips_detected = (GLOBAL_STATE->ASIC_functions.init_fn)(GLOBAL_STATE->POWER_MANAGEMENT_MODULE.frequency_value, GLOBAL_STATE->asic_count);
+    uint8_t chips_detected = (GLOBAL_STATE->ASIC_functions.init_fn)(GLOBAL_STATE->POWER_MANAGEMENT_MODULE.frequency_value, GLOBAL_STATE->asic_count, (uint32_t)0x1fffe000);
     ESP_LOGI(TAG, "%u chips detected, %u expected", chips_detected, GLOBAL_STATE->asic_count);
 
     int baud = (*GLOBAL_STATE->ASIC_functions.set_max_baud_fn)();

--- a/main/tasks/create_jobs_task.c
+++ b/main/tasks/create_jobs_task.c
@@ -30,6 +30,11 @@ void create_jobs_task(void *pvParameters)
             vTaskDelay(pdMS_TO_TICKS(100)); // Wait a bit before trying again
             continue;
         }
+        if (GLOBAL_STATE->version_mask_given) {
+            ESP_LOGI(TAG, "Set chip version rolls %i", (int)(GLOBAL_STATE->version_mask >> 13));
+            (GLOBAL_STATE->ASIC_functions.set_version_mask)(GLOBAL_STATE->version_mask);
+            GLOBAL_STATE->version_mask_given = false;
+        }
         ESP_LOGI(TAG, "New Work Dequeued %s", mining_notification->job_id);
 
         // Process this job immediately

--- a/main/tasks/create_jobs_task.c
+++ b/main/tasks/create_jobs_task.c
@@ -30,10 +30,10 @@ void create_jobs_task(void *pvParameters)
             vTaskDelay(pdMS_TO_TICKS(100)); // Wait a bit before trying again
             continue;
         }
-        if (GLOBAL_STATE->version_mask_given) {
+        if (GLOBAL_STATE->new_stratum_version_rolling_msg) {
             ESP_LOGI(TAG, "Set chip version rolls %i", (int)(GLOBAL_STATE->version_mask >> 13));
             (GLOBAL_STATE->ASIC_functions.set_version_mask)(GLOBAL_STATE->version_mask);
-            GLOBAL_STATE->version_mask_given = false;
+            GLOBAL_STATE->new_stratum_version_rolling_msg = false;
         }
         ESP_LOGI(TAG, "New Work Dequeued %s", mining_notification->job_id);
 

--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -199,11 +199,10 @@ void stratum_task(void * pvParameters)
                         ESP_LOGI(TAG, "Set stratum difficulty: %ld", SYSTEM_TASK_MODULE.stratum_difficulty);
                     }
                 } else if (stratum_api_v1_message.method == MINING_SET_VERSION_MASK ||
-                    stratum_api_v1_message.method == STRATUM_RESULT_VERSION_MASK) {
+                        stratum_api_v1_message.method == STRATUM_RESULT_VERSION_MASK) {
                     // 1fffe000
-                    ESP_LOGI(TAG, "Set version mask: %08lx", stratum_api_v1_message.version_mask);  
+                    ESP_LOGI(TAG, "Set version mask: %08lx", stratum_api_v1_message.version_mask);
                     GLOBAL_STATE->version_mask = stratum_api_v1_message.version_mask;
-                    //set the version mask after talking to stratum
                     GLOBAL_STATE->version_mask_given = true;
 
                 } else if (stratum_api_v1_message.method == STRATUM_RESULT_SUBSCRIBE) {

--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -199,12 +199,12 @@ void stratum_task(void * pvParameters)
                         ESP_LOGI(TAG, "Set stratum difficulty: %ld", SYSTEM_TASK_MODULE.stratum_difficulty);
                     }
                 } else if (stratum_api_v1_message.method == MINING_SET_VERSION_MASK ||
-                        stratum_api_v1_message.method == STRATUM_RESULT_VERSION_MASK) {
-                        // 1fffe000
-                        ESP_LOGI(TAG, "Set version mask: %08lx", stratum_api_v1_message.version_mask);  
-                        GLOBAL_STATE->version_mask = stratum_api_v1_message.version_mask;
-                        //set the version mask after talking to stratum
-                        GLOBAL_STATE->version_mask_given = true;
+                    stratum_api_v1_message.method == STRATUM_RESULT_VERSION_MASK) {
+                    // 1fffe000
+                    ESP_LOGI(TAG, "Set version mask: %08lx", stratum_api_v1_message.version_mask);  
+                    GLOBAL_STATE->version_mask = stratum_api_v1_message.version_mask;
+                    //set the version mask after talking to stratum
+                    GLOBAL_STATE->version_mask_given = true;
 
                 } else if (stratum_api_v1_message.method == STRATUM_RESULT_SUBSCRIBE) {
                     GLOBAL_STATE->extranonce_str = stratum_api_v1_message.extranonce_str;

--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -204,7 +204,6 @@ void stratum_task(void * pvParameters)
                     ESP_LOGI(TAG, "Set version mask: %08lx", stratum_api_v1_message.version_mask);
                     GLOBAL_STATE->version_mask = stratum_api_v1_message.version_mask;
                     GLOBAL_STATE->version_mask_given = true;
-
                 } else if (stratum_api_v1_message.method == STRATUM_RESULT_SUBSCRIBE) {
                     GLOBAL_STATE->extranonce_str = stratum_api_v1_message.extranonce_str;
                     GLOBAL_STATE->extranonce_2_len = stratum_api_v1_message.extranonce_2_len;

--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -200,9 +200,12 @@ void stratum_task(void * pvParameters)
                     }
                 } else if (stratum_api_v1_message.method == MINING_SET_VERSION_MASK ||
                         stratum_api_v1_message.method == STRATUM_RESULT_VERSION_MASK) {
-                    // 1fffe000
-                    ESP_LOGI(TAG, "Set version mask: %08lx", (uint32_t)0x0000f000); //stratum_api_v1_message.version_mask
-                    GLOBAL_STATE->version_mask = (uint32_t)0x0000f000;
+                        // 1fffe000
+                        ESP_LOGI(TAG, "Set version mask: %08lx", stratum_api_v1_message.version_mask);  
+                        GLOBAL_STATE->version_mask = stratum_api_v1_message.version_mask;
+                        //set the version mask after talking to stratum
+                        GLOBAL_STATE->version_mask_given = true;
+
                 } else if (stratum_api_v1_message.method == STRATUM_RESULT_SUBSCRIBE) {
                     GLOBAL_STATE->extranonce_str = stratum_api_v1_message.extranonce_str;
                     GLOBAL_STATE->extranonce_2_len = stratum_api_v1_message.extranonce_2_len;

--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -203,7 +203,7 @@ void stratum_task(void * pvParameters)
                     // 1fffe000
                     ESP_LOGI(TAG, "Set version mask: %08lx", stratum_api_v1_message.version_mask);
                     GLOBAL_STATE->version_mask = stratum_api_v1_message.version_mask;
-                    GLOBAL_STATE->version_mask_given = true;
+                    GLOBAL_STATE->new_stratum_version_rolling_msg = true;
                 } else if (stratum_api_v1_message.method == STRATUM_RESULT_SUBSCRIBE) {
                     GLOBAL_STATE->extranonce_str = stratum_api_v1_message.extranonce_str;
                     GLOBAL_STATE->extranonce_2_len = stratum_api_v1_message.extranonce_2_len;

--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -201,8 +201,8 @@ void stratum_task(void * pvParameters)
                 } else if (stratum_api_v1_message.method == MINING_SET_VERSION_MASK ||
                         stratum_api_v1_message.method == STRATUM_RESULT_VERSION_MASK) {
                     // 1fffe000
-                    ESP_LOGI(TAG, "Set version mask: %08lx", stratum_api_v1_message.version_mask);
-                    GLOBAL_STATE->version_mask = stratum_api_v1_message.version_mask;
+                    ESP_LOGI(TAG, "Set version mask: %08lx", (uint32_t)0x0000f000); //stratum_api_v1_message.version_mask
+                    GLOBAL_STATE->version_mask = (uint32_t)0x0000f000;
                 } else if (stratum_api_v1_message.method == STRATUM_RESULT_SUBSCRIBE) {
                     GLOBAL_STATE->extranonce_str = stratum_api_v1_message.extranonce_str;
                     GLOBAL_STATE->extranonce_2_len = stratum_api_v1_message.extranonce_2_len;


### PR DESCRIPTION
What: 
addresses https://github.com/skot/ESP-Miner/issues/54
version mask is now adhered to the stratum message

How:
creates set_version_mask functions for all bm chips
introduce new asic function set_asic_difficulty in global_state
during init the stratum version message has not come through so set a initial value 0x1fffe000
add a flag version_mask_given when a new stratum message comes in with a version change
the next jobs views the flag, and if true calls the set version mask and resets the flag
prints a log line with the new roll length

Testing
Compiled
tested on BM1368 
with different values of the version_rolling from the stratum msg and saw the nonces paired with versions rolled over at the correct version limit


