### PR TITLE
Suggest difficulty after auth to fix ckpool issue

### DIFF
--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -156,9 +156,6 @@ void stratum_task(void * pvParameters)
             // mining.configure - ID: 2
             STRATUM_V1_configure_version_rolling(GLOBAL_STATE->sock, &GLOBAL_STATE->version_mask);
 
-            //mining.suggest_difficulty - ID: 3
-            STRATUM_V1_suggest_difficulty(GLOBAL_STATE->sock, STRATUM_DIFFICULTY);
-
             char * username = nvs_config_get_string(NVS_CONFIG_STRATUM_USER, STRATUM_USER);
             char * password = nvs_config_get_string(NVS_CONFIG_STRATUM_PASS, STRATUM_PW);
 
@@ -166,6 +163,9 @@ void stratum_task(void * pvParameters)
             STRATUM_V1_authenticate(GLOBAL_STATE->sock, username, password);
             free(password);
             free(username);
+
+            //mining.suggest_difficulty - ID: 3
+            STRATUM_V1_suggest_difficulty(GLOBAL_STATE->sock, STRATUM_DIFFICULTY);
 
             while (1) {
                 char * line = STRATUM_V1_receive_jsonrpc_line(GLOBAL_STATE->sock);

--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -159,12 +159,12 @@ void stratum_task(void * pvParameters)
             char * username = nvs_config_get_string(NVS_CONFIG_STRATUM_USER, STRATUM_USER);
             char * password = nvs_config_get_string(NVS_CONFIG_STRATUM_PASS, STRATUM_PW);
 
-            //mining.authorize - ID: 4
+            //mining.authorize - ID: 3
             STRATUM_V1_authenticate(GLOBAL_STATE->sock, username, password);
             free(password);
             free(username);
 
-            //mining.suggest_difficulty - ID: 3
+            //mining.suggest_difficulty - ID: 4
             STRATUM_V1_suggest_difficulty(GLOBAL_STATE->sock, STRATUM_DIFFICULTY);
 
             while (1) {


### PR DESCRIPTION
ckpool requires that the client is authorized before suggesting a new mining difficulty.
> Dropping mining.suggest_difficulty from unauthorised client 300 172.0.1.242

https://bitbucket.org/ckolivas/ckpool-solo/src/d385b74b6fec45bca2d95f33c512f2827a8d90fc/src/stratifier.c#lines-6724