### PR TITLE
fix: Show mac address on log page #361

### DIFF
--- a/main/http_server/axe-os/src/app/components/logs/logs.component.html
+++ b/main/http_server/axe-os/src/app/components/logs/logs.component.html
@@ -16,6 +16,10 @@
                     <td>{{info.wifiStatus}}</td>
                 </tr>
                 <tr>
+                    <td>MAC Address:</td>
+                    <td>{{info.macAddr}}</td>
+                </tr>
+                <tr>
                     <td>Free Heap Memory:</td>
                     <td>{{info.freeHeap}}</td>
                 </tr>

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -33,6 +33,7 @@ export class SystemService {
           coreVoltage: 1200,
           coreVoltageActual: 1200,
           hostname: "Bitaxe",
+          macAddr: "2C:54:91:88:C9:E3",
           ssid: "default",
           wifiPass: "password",
           wifiStatus: "Connected!",

--- a/main/http_server/axe-os/src/models/ISystemInfo.ts
+++ b/main/http_server/axe-os/src/models/ISystemInfo.ts
@@ -15,6 +15,7 @@ export interface ISystemInfo {
     freeHeap: number,
     coreVoltage: number,
     hostname: string,
+    macAddr: string,
     ssid: string,
     wifiStatus: string,
     sharesAccepted: number,


### PR DESCRIPTION
Update to add mac address on logs page: #361 