### PR TITLE
changed BM1370 defaults in AxeOS

### DIFF
--- a/main/http_server/axe-os/src/app/components/edit/edit.component.ts
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.ts
@@ -72,9 +72,9 @@ export class EditComponent implements OnInit {
   public BM1370DropdownFrequency = [
     { name: '400', value: 400 },
     { name: '490', value: 490 },
-    { name: '525', value: 525 },
+    { name: '525 (default)', value: 525 },
     { name: '575', value: 575 },
-    { name: '596 (default)', value: 596 },
+    { name: '596', value: 596 },
     { name: '610', value: 610 },
     { name: '625', value: 625 },
   ];


### PR DESCRIPTION
set the BM1370 defaults to 525MHz/1150mV in both the NVS cvs file and the AxeOS UI