### PR TITLE
Don't allow flashing in AP mode and fix firmware upload error handling

### DIFF
--- a/main/http_server/axe-os/src/app/components/settings/settings.component.ts
+++ b/main/http_server/axe-os/src/app/components/settings/settings.component.ts
@@ -152,6 +152,10 @@ export class SettingsComponent {
               this.toastrService.error(event.statusText, 'Error');
             }
           }
+          else if (event instanceof HttpErrorResponse)
+          {
+            this.toastrService.error(event.error, 'Error');
+          }
         },
         error: (err) => {
           this.toastrService.error('Uploaded Error', 'Error');
@@ -186,6 +190,10 @@ export class SettingsComponent {
             } else {
               this.toastrService.error(event.statusText, 'Error');
             }
+          }
+          else if (event instanceof HttpErrorResponse)
+          {
+            this.toastrService.error(event.error, 'Error');
           }
         },
         error: (err) => {

--- a/main/http_server/axe-os/src/app/services/loading.service.ts
+++ b/main/http_server/axe-os/src/app/services/loading.service.ts
@@ -19,6 +19,7 @@ export class LoadingService {
             subscriber.next(value);
           },
           error: (err) => {
+            this.loading$.next(false);
             subscriber.next(err);
           },
           complete: () => {

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -475,6 +475,14 @@ static esp_err_t GET_system_info(httpd_req_t * req)
 
 esp_err_t POST_WWW_update(httpd_req_t * req)
 {
+    wifi_mode_t mode;
+    esp_wifi_get_mode(&mode);
+    if (mode == WIFI_MODE_AP || mode == WIFI_MODE_APSTA)
+    {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Not allowed in AP mode");
+        return ESP_FAIL;
+    }
+
     char buf[1000];
     int remaining = req->content_len;
 
@@ -521,6 +529,14 @@ esp_err_t POST_WWW_update(httpd_req_t * req)
  */
 esp_err_t POST_OTA_update(httpd_req_t * req)
 {
+    wifi_mode_t mode;
+    esp_wifi_get_mode(&mode);
+    if (mode == WIFI_MODE_AP || mode == WIFI_MODE_APSTA)
+    {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Not allowed in AP mode");
+        return ESP_FAIL;
+    }
+    
     char buf[1000];
     esp_ota_handle_t ota_handle;
     int remaining = req->content_len;

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -490,13 +490,13 @@ esp_err_t POST_WWW_update(httpd_req_t * req)
         esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_SPIFFS, "www");
     if (www_partition == NULL) {
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "WWW partition not found");
-        return ESP_FAIL;
+        return ESP_OK;
     }
 
     // Don't attempt to write more than what can be stored in the partition
     if (remaining > www_partition->size) {
         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "File provided is too large for device");
-        return ESP_FAIL;
+        return ESP_OK;
     }
 
     // Erase the entire www partition before writing
@@ -509,12 +509,12 @@ esp_err_t POST_WWW_update(httpd_req_t * req)
             continue;
         } else if (recv_len <= 0) {
             httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Protocol Error");
-            return ESP_FAIL;
+            return ESP_OK;
         }
 
         if (esp_partition_write(www_partition, www_partition->size - remaining, (const void *) buf, recv_len) != ESP_OK) {
             httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Write Error");
-            return ESP_FAIL;
+            return ESP_OK;
         }
 
         remaining -= recv_len;
@@ -534,7 +534,7 @@ esp_err_t POST_OTA_update(httpd_req_t * req)
     if (mode == WIFI_MODE_AP || mode == WIFI_MODE_APSTA)
     {
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Not allowed in AP mode");
-        return ESP_FAIL;
+        return ESP_OK;
     }
     
     char buf[1000];
@@ -554,14 +554,14 @@ esp_err_t POST_OTA_update(httpd_req_t * req)
             // Serious Error: Abort OTA
         } else if (recv_len <= 0) {
             httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Protocol Error");
-            return ESP_FAIL;
+            return ESP_OK;
         }
 
         // Successful Upload: Flash firmware chunk
         if (esp_ota_write(ota_handle, (const void *) buf, recv_len) != ESP_OK) {
             esp_ota_abort(ota_handle);
             httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Flash Error");
-            return ESP_FAIL;
+            return ESP_OK;
         }
 
         remaining -= recv_len;
@@ -570,7 +570,7 @@ esp_err_t POST_OTA_update(httpd_req_t * req)
     // Validate and switch to new OTA image and reboot
     if (esp_ota_end(ota_handle) != ESP_OK || esp_ota_set_boot_partition(ota_partition) != ESP_OK) {
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Validation / Activation Error");
-        return ESP_FAIL;
+        return ESP_OK;
     }
 
     httpd_resp_sendstr(req, "Firmware update complete, rebooting now!\n");

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -480,7 +480,7 @@ esp_err_t POST_WWW_update(httpd_req_t * req)
     if (mode == WIFI_MODE_AP || mode == WIFI_MODE_APSTA)
     {
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Not allowed in AP mode");
-        return ESP_FAIL;
+        return ESP_OK;
     }
 
     char buf[1000];


### PR DESCRIPTION
 - Prevent flashing of the firmware when in AP mode.
 - Fixed error handling when the firmware flashing fails.