### PR TITLE
Enable automatic build and release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       with:
         submodules: 'recursive'
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '22'
     - name: Build web dist
@@ -24,7 +24,7 @@ jobs:
         target: esp32s3
         command: GITHUB_ACTIONS="true" idf.py build
         path: '.'
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
         cache: 'pip'

--- a/.github/workflows/release-factory.yml
+++ b/.github/workflows/release-factory.yml
@@ -1,0 +1,54 @@
+name: Build & Release Factory Images
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: "Factory ${{ matrix.build_type }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: ["102", "202", "204", "401", "402", "403", "601"]
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '22'
+      - name: Build web dist
+        working-directory: ./main/http_server/axe-os
+        run: |
+          npm ci
+          npm run build
+      - name: esp-idf build
+        uses: espressif/esp-idf-ci-action@v1
+        with:
+          esp_idf_version: v5.3.1
+          target: esp32s3
+          command: GITHUB_ACTIONS="true" idf.py build
+          path: '.'
+      - name: "esp-idf build factory config for ${{ matrix.build_type }}"
+        uses: espressif/esp-idf-ci-action@v1
+        with:
+          esp_idf_version: v5.3.1
+          target: esp32s3
+          command: /opt/esp/idf/components/nvs_flash/nvs_partition_generator/nvs_partition_gen.py generate config-${{ matrix.build_type }}.cvs config.bin 0x6000
+          path: '.'
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+      - run: pip install esptool
+      - name: "Create factory image for ${{ matrix.build_type }}-${{ github.ref_name }}"
+        run: "./merge_bin.sh -c esp-miner-factory-${{ matrix.build_type }}-${{ github.ref_name }}.bin"
+      - name: Release esp-miner.bin
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: "esp-miner-factory-${{ matrix.build_type }}-${{ github.ref_name }}.bin"

--- a/.github/workflows/release-factory.yml
+++ b/.github/workflows/release-factory.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           submodules: 'recursive'
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
       - name: Build web dist
@@ -40,7 +40,7 @@ jobs:
           target: esp32s3
           command: /opt/esp/idf/components/nvs_flash/nvs_partition_generator/nvs_partition_gen.py generate config-${{ matrix.build_type }}.cvs config.bin 0x6000
           path: '.'
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: 'pip'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
-name: Build Firmware
-on: [push, pull_request]
+name: Build & Release Firmware
+on:
+  push:
+    tags:
+      - '*'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -39,10 +42,20 @@ jobs:
     - name: upload esp-miner.bin
       uses: actions/upload-artifact@v3
       with:
-        name: esp-miner-ota.bin
+        name: esp-miner.bin
         path: ./build/esp-miner.bin
     - name: upload www.bin
       uses: actions/upload-artifact@v3
       with:
         name: www.bin
         path: ./build/www.bin
+    - name: Release www.bin
+      uses: softprops/action-gh-release@v2
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: ./build/www.bin
+    - name: Release esp-miner.bin
+      uses: softprops/action-gh-release@v2
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: ./build/esp-miner.bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       with:
         submodules: 'recursive'
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '22'
     - name: Build web dist
@@ -27,7 +27,7 @@ jobs:
         target: esp32s3
         command: GITHUB_ACTIONS="true" idf.py build
         path: '.'
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
         cache: 'pip'


### PR DESCRIPTION
This patch enables firmware and factory images to be automatically built and uploaded when we tag a new release.

![image](https://github.com/user-attachments/assets/2473623d-f6cf-4cd1-9ccb-a038f3e5a78a)
![image](https://github.com/user-attachments/assets/0e758809-a6b0-4ef6-b65e-6a919c06129c)
