### PR TITLE
Re-worked how we publish artifacts when releasing new builds

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -1,0 +1,64 @@
+name: Build & Release Firmware [Pre-Release]
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+    - name: Build web dist
+      working-directory: ./main/http_server/axe-os
+      run: |
+        npm ci
+        npm run build
+    - name: esp-idf build
+      uses: espressif/esp-idf-ci-action@v1
+      with:
+        esp_idf_version: v5.3.1
+        target: esp32s3
+        command: GITHUB_ACTIONS="true" idf.py build
+        path: '.'
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+        cache: 'pip'
+    - run: pip install esptool
+    - name: "Create factory/merged image"
+      run: "./merge_bin.sh ./esp-miner-merged.bin"
+    - name: upload esp-miner-merged.bin
+      uses: actions/upload-artifact@v3
+      with:
+        name: esp-miner-factory.bin
+        path: ./esp-miner-merged.bin
+    - name: upload esp-miner.bin
+      uses: actions/upload-artifact@v3
+      with:
+        name: esp-miner.bin
+        path: ./build/esp-miner.bin
+    - name: upload www.bin
+      uses: actions/upload-artifact@v3
+      with:
+        name: www.bin
+        path: ./build/www.bin
+    - name: Release www.bin
+      uses: softprops/action-gh-release@v2
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        prerelease: true
+        files: ./build/www.bin
+    - name: Release esp-miner.bin
+      uses: softprops/action-gh-release@v2
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        prerelease: true
+        files: ./build/esp-miner.bin

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -2,7 +2,7 @@ name: Build & Release Firmware [Pre-Release]
 
 on:
   release:
-    types: [released]
+    types: [prereleased]
 
 jobs:
   build:

--- a/.github/workflows/release-factory-beta.yml
+++ b/.github/workflows/release-factory-beta.yml
@@ -1,0 +1,55 @@
+name: Build & Release Factory Images [Pre-Release]
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: "Factory ${{ matrix.build_type }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: ["102", "202", "204", "401", "402", "403", "601"]
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Build web dist
+        working-directory: ./main/http_server/axe-os
+        run: |
+          npm ci
+          npm run build
+      - name: esp-idf build
+        uses: espressif/esp-idf-ci-action@v1
+        with:
+          esp_idf_version: v5.3.1
+          target: esp32s3
+          command: GITHUB_ACTIONS="true" idf.py build
+          path: '.'
+      - name: "esp-idf build factory config for ${{ matrix.build_type }}"
+        uses: espressif/esp-idf-ci-action@v1
+        with:
+          esp_idf_version: v5.3.1
+          target: esp32s3
+          command: /opt/esp/idf/components/nvs_flash/nvs_partition_generator/nvs_partition_gen.py generate config-${{ matrix.build_type }}.cvs config.bin 0x6000
+          path: '.'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+      - run: pip install esptool
+      - name: "Create factory image for ${{ matrix.build_type }}-${{ github.ref_name }}"
+        run: "./merge_bin.sh -c esp-miner-factory-${{ matrix.build_type }}-${{ github.ref_name }}.bin"
+      - name: Release esp-miner.bin
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          prerelease: true
+          files: "esp-miner-factory-${{ matrix.build_type }}-${{ github.ref_name }}.bin"

--- a/.github/workflows/release-factory-beta.yml
+++ b/.github/workflows/release-factory-beta.yml
@@ -2,7 +2,7 @@ name: Build & Release Factory Images [Pre-Release]
 
 on:
   release:
-    types: [released]
+    types: [prereleased]
 
 jobs:
   build:

--- a/.github/workflows/release-factory.yml
+++ b/.github/workflows/release-factory.yml
@@ -51,4 +51,5 @@ jobs:
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
+          prerelease: true
           files: "esp-miner-factory-${{ matrix.build_type }}-${{ github.ref_name }}.bin"

--- a/.github/workflows/release-factory.yml
+++ b/.github/workflows/release-factory.yml
@@ -1,8 +1,8 @@
-name: Build & Release Factory Images
+name: Build & Release Factory Images [Release]
+
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [released]
 
 jobs:
   build:
@@ -51,5 +51,4 @@ jobs:
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          prerelease: true
           files: "esp-miner-factory-${{ matrix.build_type }}-${{ github.ref_name }}.bin"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,11 @@ jobs:
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
+        prerelease: true
         files: ./build/www.bin
     - name: Release esp-miner.bin
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
+        prerelease: true
         files: ./build/esp-miner.bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
-name: Build & Release Firmware
+name: Build & Release Firmware [Release]
+
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [released]
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -53,11 +54,9 @@ jobs:
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        prerelease: true
         files: ./build/www.bin
     - name: Release esp-miner.bin
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        prerelease: true
         files: ./build/esp-miner.bin


### PR DESCRIPTION
Reworked how we publish new buiildd artifacts. Tags no longer automatically trigger artifacts to get published. Instead builds needs to be published using Github Releases to generate release artifacts.