### PR TITLE
Fix api not handling errors properly

### DIFF
--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -181,7 +181,7 @@ static esp_err_t rest_common_get_handler(httpd_req_t * req)
                 httpd_resp_sendstr_chunk(req, NULL);
                 /* Respond with 500 Internal Server Error */
                 httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to send file");
-                return ESP_FAIL;
+                return ESP_OK;
             }
         }
     } while (read_bytes > 0);
@@ -192,7 +192,6 @@ static esp_err_t rest_common_get_handler(httpd_req_t * req)
     httpd_resp_send_chunk(req, NULL, 0);
     return ESP_OK;
 }
-
 
 static esp_err_t handle_options_request(httpd_req_t * req)
 {
@@ -223,14 +222,14 @@ static esp_err_t PATCH_update_settings(httpd_req_t * req)
     if (total_len >= SCRATCH_BUFSIZE) {
         /* Respond with 500 Internal Server Error */
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "content too long");
-        return ESP_FAIL;
+        return ESP_OK;
     }
     while (cur_len < total_len) {
         received = httpd_req_recv(req, buf + cur_len, total_len);
         if (received <= 0) {
             /* Respond with 500 Internal Server Error */
             httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to post control value");
-            return ESP_FAIL;
+            return ESP_OK;
         }
         cur_len += received;
     }

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -198,7 +198,7 @@ static esp_err_t handle_options_request(httpd_req_t * req)
     // Set CORS headers for OPTIONS request
     if (set_cors_headers(req) != ESP_OK) {
         httpd_resp_send_500(req);
-        return ESP_FAIL;
+        return ESP_OK;
     }
 
     // Send a blank response for OPTIONS request
@@ -212,7 +212,7 @@ static esp_err_t PATCH_update_settings(httpd_req_t * req)
     // Set CORS headers
     if (set_cors_headers(req) != ESP_OK) {
         httpd_resp_send_500(req);
-        return ESP_FAIL;
+        return ESP_OK;
     }
 
     int total_len = req->content_len;
@@ -318,7 +318,6 @@ static esp_err_t POST_restart(httpd_req_t * req)
     return ESP_OK;
 }
 
-
 /* Simple handler for getting system handler */
 static esp_err_t GET_system_info(httpd_req_t * req)
 {
@@ -327,7 +326,7 @@ static esp_err_t GET_system_info(httpd_req_t * req)
     // Set CORS headers
     if (set_cors_headers(req) != ESP_OK) {
         httpd_resp_send_500(req);
-        return ESP_FAIL;
+        return ESP_OK;
     }
 
 


### PR DESCRIPTION
I found this when implementing the firmware protection that when sending `httpd_resp_send_err` if you return `ESP_FAIL` it will trigger a TCP Reset, hiding the actual error message from the user.