### PR TITLE
Fix ESP-NOW warning by limiting ap max_connections

### DIFF
--- a/components/connect/connect.c
+++ b/components/connect/connect.c
@@ -49,7 +49,7 @@
 /* FreeRTOS event group to signal when we are connected*/
 static EventGroupHandle_t s_wifi_event_group;
 
-static const char * TAG = "wifi station";
+static const char * TAG = "wifi_station";
 
 static int s_retry_num = 0;
 
@@ -102,7 +102,7 @@ esp_netif_t * wifi_init_softap(void)
     strncpy((char *) wifi_ap_config.ap.ssid, ssid_with_mac, sizeof(wifi_ap_config.ap.ssid));
     wifi_ap_config.ap.ssid_len = strlen(ssid_with_mac);
     wifi_ap_config.ap.channel = 1;
-    wifi_ap_config.ap.max_connection = 30;
+    wifi_ap_config.ap.max_connection = 10;
     wifi_ap_config.ap.authmode = WIFI_AUTH_OPEN;
     wifi_ap_config.ap.pmf_cfg.required = false;
 


### PR DESCRIPTION
This removes the warning on boot:

_warning Affected by the ESP-NOW encrypt num, set the max connection num to ##_

The ESP32 can only handle 17 encrypted keys. There are 7 in use for ESPNOW (CONFIG_ESP_WIFI_ESPNOW_MAX_ENCRYPT_NUM), which leave 10.

Some context here: https://github.com/espressif/esp-idf/issues/11697