### PR TITLE
replaced default address with a prompt

### DIFF
--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -44,7 +44,7 @@ menu "Stratum Configuration"
 
     config STRATUM_USER
         string "Stratum username"
-        default "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa.bitaxe"
+        default "replace-this-with-your-btc-address.bitaxe"
         help
             Stratum user to use with pool
 
@@ -56,7 +56,7 @@ menu "Stratum Configuration"
 
     config FALLBACK_STRATUM_USER
         string "Fallback Stratum username"
-        default "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa.bitaxe"
+        default "replace-this-with-your-btc-address.bitaxe"
         help
             Fallback Stratum user to use with pool
 


### PR DESCRIPTION
tldr - This PR changes the initial defaults for both fields to something that indicates to the user that they should replace the value with their btc address.

Rationale - I recently updated from a fw version which did not contain the "Fallback" config fields, and was surprised to see an unfamiliar field with a bitcoin address (not mine) prefilled. After investigating what was going on, I realize that this is the same address in the initial default, which of course I changed when initially setting up the unit. However, being an update, I had forgotten about that initial setup, so, the surprise set off alarm bells. It prompted me to make this change to prevent this experience for updaters, while also remaining clear for initial setup.
