### PR TITLE
fix: Temp suffix & 5v marker

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -99,10 +99,15 @@
                     <div class="col-12">
 
                         <h6>Input Voltage <span style="float: right;">{{info.voltage}} V</span></h6>
-                        <p-progressBar [value]="(info.voltage / 5.5) * 100" [style]="{ height: '6px' }" >
-                            <ng-template pTemplate="content" let-value>
-                            </ng-template>
-                        </p-progressBar>
+                        <div class="relative">
+                            <p-progressBar [value]="(info.voltage / 5.5) * 100" [style]="{ height: '6px' }">
+                                <ng-template pTemplate="content" let-value></ng-template>
+                            </p-progressBar>
+                            <!-- Add marker at 5.0V (90.91% of 5.5V) -->
+                            <div class="absolute bg-white" style="left: 90.5%; top: 0; width: 3px; height: 6px;">
+                                <small class="absolute text-white" style="top: -1.25rem; transform: translateX(-50%)">5.0</small>
+                            </div>
+                        </div>
                         <span class="danger" *ngIf="info.voltage < 4.8">&nbsp; Danger: Low voltage</span>
                     </div>
 

--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -64,7 +64,7 @@ export class HomeComponent {
           data: [],
           fill: false,
           backgroundColor: primaryColor +  '30',
-          borderColor: primaryColor + '30',
+          borderColor: primaryColor + '60',
           tension: 0,
           pointRadius: 0,
           borderWidth: 2,
@@ -103,7 +103,11 @@ export class HomeComponent {
               if (label) {
                 label += ': ';
               }
-              label += HashSuffixPipe.transform(tooltipItem.raw);
+              if (tooltipItem.dataset.label === 'ASIC Temp') {
+                label += tooltipItem.raw + '°C';
+              } else {
+                label += HashSuffixPipe.transform(tooltipItem.raw);
+              }
               return label;
             }
           }
@@ -139,7 +143,8 @@ export class HomeComponent {
           display: true,
           position: 'right',
           ticks: {
-            color: textColorSecondary
+            color: textColorSecondary,
+            callback: (value: number) => value + '°C'
           },
           grid: {
             drawOnChartArea: false,


### PR DESCRIPTION
### Description:

- Show current suffix for temp points on the chart and add the suffix to the axes.
- Make the average hashrate a little easier to see
- Add a 5.0v marker on the input voltage progress bar