### PR TITLE
small change to only-gzip.js to remove warning

### DIFF
--- a/main/http_server/axe-os/only-gzip.js
+++ b/main/http_server/axe-os/only-gzip.js
@@ -14,7 +14,7 @@ fs.readdir(directory, (err, files) => {
 
             if (stats.isDirectory()) {
                 // If it's a directory, call rmdir after deleting its contents
-                fs.rmdir(filePath, { recursive: true }, (err) => {
+                fs.rm(filePath, { recursive: true }, (err) => {
                     if (err) throw err;
                     console.log(`Removed directory: ${filePath}`);
                 });


### PR DESCRIPTION
we were getting the following warning;

```
(node:69549) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)
```

So I made the change it suggests, and the warning went away.

Seems to be working fine?