### PR TITLE
fix: Better restart feedback & attempt to fix CORS

### DIFF
--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -132,10 +132,16 @@ export class SwarmComponent implements OnInit, OnDestroy {
   }
 
   public restart(axe: any) {
-    this.systemService.restart(`http://${axe.IP}`).subscribe(res => {
-
+    this.systemService.restart(`http://${axe.IP}`).pipe(
+      catchError(error => {
+        this.toastr.error('Failed to restart device', 'Error');
+        return of(null);
+      })
+    ).subscribe(res => {
+      if (res !== null) {
+        this.toastr.success('Bitaxe restarted', 'Success');
+      }
     });
-    this.toastr.success('Success!', 'Bitaxe restarted');
   }
 
   public remove(axeOs: any) {

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -320,6 +320,12 @@ static esp_err_t PATCH_update_settings(httpd_req_t * req)
 
 static esp_err_t POST_restart(httpd_req_t * req)
 {
+    // Set CORS headers
+    if (set_cors_headers(req) != ESP_OK) {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+
     ESP_LOGI(TAG, "Restarting System because of API Request");
 
     // Send HTTP response before restarting
@@ -709,6 +715,10 @@ esp_err_t start_rest_server(void * pvParameters)
     httpd_uri_t system_restart_uri = {
         .uri = "/api/system/restart", .method = HTTP_POST, .handler = POST_restart, .user_ctx = rest_context};
     httpd_register_uri_handler(server, &system_restart_uri);
+
+    httpd_uri_t system_restart_options_uri = {
+        .uri = "/api/system/restart", .method = HTTP_OPTIONS, .handler = handle_options_request, .user_ctx = NULL};
+    httpd_register_uri_handler(server, &system_restart_options_uri);
 
     httpd_uri_t update_system_settings_uri = {
         .uri = "/api/system", .method = HTTP_PATCH, .handler = PATCH_update_settings, .user_ctx = rest_context};

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -323,7 +323,7 @@ static esp_err_t POST_restart(httpd_req_t * req)
     // Set CORS headers
     if (set_cors_headers(req) != ESP_OK) {
         httpd_resp_send_500(req);
-        return ESP_FAIL;
+        return ESP_OK;
     }
 
     ESP_LOGI(TAG, "Restarting System because of API Request");


### PR DESCRIPTION
## Description

- If swarm restart fails, show an error instead of Success
- Attempt to fix CORS error that prevents restart from swarm

Should address #154 