### PR TITLE
Swarm restart returns text, not json

### DIFF
--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -69,7 +69,7 @@ export class SystemService {
   }
 
   public restart(uri: string = '') {
-    return this.httpClient.post(`${uri}/api/system/restart`, {});
+    return this.httpClient.post(`${uri}/api/system/restart`, {}, {responseType: 'text'});
   }
 
   public updateSystem(uri: string = '', update: any) {


### PR DESCRIPTION
This fixes an error where restarting throws an error in the UI even though the restart was successful.