### PR TITLE
Parse stratum api reject reason

### DIFF
--- a/components/stratum/include/stratum_api.h
+++ b/components/stratum/include/stratum_api.h
@@ -59,6 +59,7 @@ typedef struct
     uint32_t version_mask;
     // result
     bool response_success;
+    char * error_str;
 } StratumApiV1Message;
 
 void STRATUM_V1_reset_uid();

--- a/components/stratum/stratum_api.c
+++ b/components/stratum/stratum_api.c
@@ -146,6 +146,7 @@ void STRATUM_V1_parse(StratumApiV1Message * message, const char * stratum_json)
         // parse results
         cJSON * result_json = cJSON_GetObjectItem(json, "result");
         cJSON * error_json = cJSON_GetObjectItem(json, "error");
+        cJSON * reject_reason_json = cJSON_GetObjectItem(json, "reject-reason");
 
         //if the result is null, then it's a fail
         if (result_json == NULL) {
@@ -157,6 +158,15 @@ void STRATUM_V1_parse(StratumApiV1Message * message, const char * stratum_json)
                 result = STRATUM_RESULT_SETUP;
             } else {
                 result = STRATUM_RESULT;
+            }
+            if (cJSON_IsArray(error_json)) {
+                int len = cJSON_GetArraySize(error_json);
+                if (len >= 2) {
+                    cJSON * error_msg = cJSON_GetArrayItem(error_json, 1);
+                    if (cJSON_IsString(error_msg)) {
+                        message->error_str = strdup(cJSON_GetStringValue(error_msg));
+                    }
+                }
             }
             message->response_success = false;
 
@@ -171,6 +181,11 @@ void STRATUM_V1_parse(StratumApiV1Message * message, const char * stratum_json)
                 message->response_success = true;
             } else {
                 message->response_success = false;
+                if (!cJSON_IsNull(reject_reason_json)) {
+                    if (cJSON_IsString(reject_reason_json)) {
+                        message->error_str = strdup(cJSON_GetStringValue(reject_reason_json));
+                    }                
+                }
             }
         
         //if the id is STRATUM_ID_SUBSCRIBE parse it

--- a/components/stratum/test/test_stratum_json.c
+++ b/components/stratum/test/test_stratum_json.c
@@ -153,4 +153,16 @@ TEST_CASE("Parse stratum result error", "[stratum]")
     TEST_ASSERT_EQUAL(1, stratum_api_v1_message.message_id);
     TEST_ASSERT_EQUAL(STRATUM_RESULT, stratum_api_v1_message.method);
     TEST_ASSERT_FALSE(stratum_api_v1_message.response_success);
+    TEST_ASSERT_EQUAL("Job not found", stratum_api_v1_message.error_str);
+}
+
+TEST_CASE("Parse stratum result alternative error", "[stratum]")
+{
+    StratumApiV1Message stratum_api_v1_message = {};
+    const char *json_string = "{\"reject-reason\":\"Above target\",\"result\":false,\"error\":null,\"id\":8}";
+    STRATUM_V1_parse(&stratum_api_v1_message, json_string);
+    TEST_ASSERT_EQUAL(1, stratum_api_v1_message.message_id);
+    TEST_ASSERT_EQUAL(STRATUM_RESULT, stratum_api_v1_message.method);
+    TEST_ASSERT_FALSE(stratum_api_v1_message.response_success);
+    TEST_ASSERT_EQUAL("Above target 2", stratum_api_v1_message.error_str);
 }

--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -299,14 +299,14 @@ void stratum_task(void * pvParameters)
                     ESP_LOGI(TAG, "message result accepted");
                     SYSTEM_notify_accepted_share(GLOBAL_STATE);
                 } else {
-                    ESP_LOGW(TAG, "message result rejected");
+                    ESP_LOGW(TAG, "message result rejected: %s", stratum_api_v1_message.error_str ? stratum_api_v1_message.error_str : "unknown");
                     SYSTEM_notify_rejected_share(GLOBAL_STATE);
                 }
             } else if (stratum_api_v1_message.method == STRATUM_RESULT_SETUP) {
                 if (stratum_api_v1_message.response_success) {
                     ESP_LOGI(TAG, "setup message accepted");
                 } else {
-                    ESP_LOGE(TAG, "setup message rejected");
+                    ESP_LOGE(TAG, "setup message rejected: %s", stratum_api_v1_message.error_str ? stratum_api_v1_message.error_str : "unknown");
                 }
             }
         }


### PR DESCRIPTION
Initial implementation of parsing reject reasons as discussed in #264. It can handle two formats, the error array and the reject-reason string. If other flavours are found, it should be fairly trivial to extend the parsing.

This only handles the parsing aspect, feeding back to the front-end will be a separate issue.

I extended an existing and added a unit test, but I don't know how to run them.