### PR TITLE
fix: correct json_rpc_buffer initialization order

### DIFF
--- a/components/stratum/stratum_api.c
+++ b/components/stratum/stratum_api.c
@@ -37,11 +37,11 @@ void STRATUM_V1_initialize_buffer()
 {
     json_rpc_buffer = malloc(BUFFER_SIZE);
     json_rpc_buffer_size = BUFFER_SIZE;
-    memset(json_rpc_buffer, 0, BUFFER_SIZE);
     if (json_rpc_buffer == NULL) {
         printf("Error: Failed to allocate memory for buffer\n");
         exit(1);
     }
+    memset(json_rpc_buffer, 0, BUFFER_SIZE);
 }
 
 void cleanup_stratum_buffer()


### PR DESCRIPTION
While reviewing #471, noticed that `json_rpc_buffer` initialization tries to `memset` before checking if the `malloc` was successful.

This moves the `memset` after the check.

Did a basic test by building and running on a Supra 401.  Started mining on testnet4 on a ckpool instance.  Jobs were received and shares were accepted.

Note: The malloc failure is unlikely to occur, so we're not seeing an issue now, but if it does occur (e.g. other future code changes chew up too much heap), then we could actually see the error in the log.