### PR TITLE
doc: update readme to mention recovery page

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,3 +65,7 @@ Some API examples in curl:
 ## Administration
 
 The firmware hosts a small web server on port 80 for administrative purposes. Once the Bitaxe device is connected to the local network, the admin web front end may be accessed via a web browser connected to the same network at `http://<IP>`, replacing `IP` with the LAN IP address of the Bitaxe device, or `http://bitaxe`, provided your network supports mDNS configuration.
+
+### Recovery
+
+In the event that the admin web front end is inaccessible, for example because of an unsuccessful firmware update (`www.bin`), a recovery page can be accessed at `http://<IP>/recovery`.


### PR DESCRIPTION
Mentions the recovery page in the readme.


![image](https://github.com/user-attachments/assets/f9ccd771-6cde-4e61-8a16-eb88ecb6f6c5)
