### PR TITLE
Reduce invalid job found log from error to warning

### DIFF
--- a/components/asic/bm1366.c
+++ b/components/asic/bm1366.c
@@ -500,7 +500,7 @@ task_result * BM1366_proccess_work(void * pvParameters)
     GlobalState * GLOBAL_STATE = (GlobalState *) pvParameters;
 
     if (GLOBAL_STATE->valid_jobs[job_id] == 0) {
-        ESP_LOGE(TAG, "Invalid job found, 0x%02X", job_id);
+        ESP_LOGI(TAG, "Invalid job found, 0x%02X", job_id);
         return NULL;
     }
 

--- a/components/asic/bm1366.c
+++ b/components/asic/bm1366.c
@@ -500,7 +500,7 @@ task_result * BM1366_proccess_work(void * pvParameters)
     GlobalState * GLOBAL_STATE = (GlobalState *) pvParameters;
 
     if (GLOBAL_STATE->valid_jobs[job_id] == 0) {
-        ESP_LOGI(TAG, "Invalid job found, 0x%02X", job_id);
+        ESP_LOGW(TAG, "Invalid job found, 0x%02X", job_id);
         return NULL;
     }
 

--- a/components/asic/bm1368.c
+++ b/components/asic/bm1368.c
@@ -433,7 +433,7 @@ task_result * BM1368_proccess_work(void * pvParameters)
     GlobalState * GLOBAL_STATE = (GlobalState *) pvParameters;
 
     if (GLOBAL_STATE->valid_jobs[job_id] == 0) {
-        ESP_LOGE(TAG, "Invalid job found, 0x%02X", job_id);
+        ESP_LOGI(TAG, "Invalid job found, 0x%02X", job_id);
         return NULL;
     }
 

--- a/components/asic/bm1368.c
+++ b/components/asic/bm1368.c
@@ -433,7 +433,7 @@ task_result * BM1368_proccess_work(void * pvParameters)
     GlobalState * GLOBAL_STATE = (GlobalState *) pvParameters;
 
     if (GLOBAL_STATE->valid_jobs[job_id] == 0) {
-        ESP_LOGI(TAG, "Invalid job found, 0x%02X", job_id);
+        ESP_LOGW(TAG, "Invalid job found, 0x%02X", job_id);
         return NULL;
     }
 

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -519,7 +519,7 @@ task_result * BM1370_proccess_work(void * pvParameters)
     GlobalState * GLOBAL_STATE = (GlobalState *) pvParameters;
 
     if (GLOBAL_STATE->valid_jobs[job_id] == 0) {
-        ESP_LOGE(TAG, "Invalid job nonce found, 0x%02X", job_id);
+        ESP_LOGI(TAG, "Invalid job nonce found, 0x%02X", job_id);
         return NULL;
     }
 

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -519,7 +519,7 @@ task_result * BM1370_proccess_work(void * pvParameters)
     GlobalState * GLOBAL_STATE = (GlobalState *) pvParameters;
 
     if (GLOBAL_STATE->valid_jobs[job_id] == 0) {
-        ESP_LOGI(TAG, "Invalid job nonce found, 0x%02X", job_id);
+        ESP_LOGW(TAG, "Invalid job nonce found, 0x%02X", job_id);
         return NULL;
     }
 

--- a/components/asic/bm1397.c
+++ b/components/asic/bm1397.c
@@ -454,7 +454,7 @@ task_result *BM1397_proccess_work(void *pvParameters)
     GlobalState *GLOBAL_STATE = (GlobalState *)pvParameters;
     if (GLOBAL_STATE->valid_jobs[rx_job_id] == 0)
     {
-        ESP_LOGI(TAG, "Invalid job nonce found, id=%d", rx_job_id);
+        ESP_LOGW(TAG, "Invalid job nonce found, id=%d", rx_job_id);
         return NULL;
     }
 

--- a/main/tasks/asic_result_task.c
+++ b/main/tasks/asic_result_task.c
@@ -28,7 +28,7 @@ void ASIC_result_task(void *pvParameters)
 
         if (GLOBAL_STATE->valid_jobs[job_id] == 0)
         {
-            ESP_LOGI(TAG, "Invalid job nonce found, 0x%02X", job_id);
+            ESP_LOGW(TAG, "Invalid job nonce found, 0x%02X", job_id);
             continue;
         }
 


### PR DESCRIPTION
While this message can be useful, most commonly it is seen after receiving a mining.notify, or briefly getting disconnected from the pool. changing it from a ERROR to WARNING log message to not scare users.

This also makes the implementation more consistent, as in some places and chips we already logged as ERROR and in other places as INFO.