### PR TITLE
api: add stratum difficulty

### DIFF
--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -376,6 +376,7 @@ static esp_err_t GET_system_info(httpd_req_t * req)
     cJSON_AddNumberToObject(root, "hashRate", GLOBAL_STATE->SYSTEM_MODULE.current_hashrate);
     cJSON_AddStringToObject(root, "bestDiff", GLOBAL_STATE->SYSTEM_MODULE.best_diff_string);
     cJSON_AddStringToObject(root, "bestSessionDiff", GLOBAL_STATE->SYSTEM_MODULE.best_session_diff_string);
+    cJSON_AddNumberToObject(root, "stratumDiff", GLOBAL_STATE->stratum_difficulty);
 
     cJSON_AddNumberToObject(root, "isUsingFallbackStratum", GLOBAL_STATE->SYSTEM_MODULE.is_using_fallback);
 


### PR DESCRIPTION
Fixes Issue #482
Adds current stratum difficulty to the api/system/info endpoint.

Tested mining on testnet4 (difficulty 1000)
```
$ curl <bitaxe_IP_address>/api/system/info
{
...
        "stratumDiff":  1000,
```

then stopped the testnet4 stratum server to induce failover to the secondary stratum server (mainnet, Ocean):
```
$ curl <bitaxe_IP_address>/api/system/info
{
...
        "stratumDiff":  262144,
```