### PR TITLE
Swarm styles, refresh on load, more combined stats, more info in table

### DIFF
--- a/main/http_server/axe-os/src/app/app.module.ts
+++ b/main/http_server/axe-os/src/app/app.module.ts
@@ -24,6 +24,7 @@ import { DateAgoPipe } from './pipes/date-ago.pipe';
 import { HashSuffixPipe } from './pipes/hash-suffix.pipe';
 import { PrimeNGModule } from './prime-ng.module';
 import { MessageModule } from 'primeng/message';
+import { TooltipModule } from 'primeng/tooltip';
 
 const components = [
   AppComponent,
@@ -59,7 +60,8 @@ const components = [
     CommonModule,
     PrimeNGModule,
     AppLayoutModule,
-    MessageModule
+    MessageModule,
+    TooltipModule
   ],
   providers: [
     { provide: LocationStrategy, useClass: HashLocationStrategy },

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
@@ -1,7 +1,7 @@
-<div class="card">
+<div class="card p-3">
 
     <form [formGroup]="form">
-        <div class="field grid p-fluid">
+        <div class="field grid p-fluid mb-0">
             <label htmlFor="ip" class="col-12 mb-2 md:col-4 md:mb-0">Manual Addition</label>
             <div class="col-12 md:col-8">
                 <p-inputGroup>

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
@@ -34,9 +34,15 @@
     </div>
 </div>
 
-<div class="flex justify-content-between mt-4 mb-4">
-    <div class="text-sm md:text-base">
-        Total Hash Rate: <span class="text-primary">{{totalHashRate * 1000000000 | hashSuffix}}</span>
+<div class="flex flex-column sm:flex-row w-full gap-2 xl:gap-4 mt-4 mb-4">
+    <div class="card mb-0 w-full text-center p-4">
+        Total Hash Rate: <span class="text-primary">{{totals.hashRate * 1000000000 | hashSuffix}}</span>
+    </div>
+    <div class="card mb-0 w-full text-center p-4">
+        Total Power: <span class="text-primary">{{totals.power | number: '1.1-1'}} <small>W</small></span>
+    </div>
+    <div class="card mb-0 w-full text-center p-4">
+        Best Diff: <span class="text-primary">{{totals.bestDiff}}</span>
     </div>
 </div>
 

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
@@ -65,7 +65,7 @@
             <tr>
                 <td>
                     <a class="text-primary" [href]="'http://'+axe.IP" target="_blank">{{axe.IP}}</a>
-                    <div class="text-xs">{{axe.hostname}}</div>
+                    <div class="text-sm">{{axe.hostname}}</div>
                 </td>
                 <td>{{axe.hashRate * 1000000000 | hashSuffix}}</td>
                 <td>{{axe.uptimeSeconds | dateAgo}}</td>
@@ -75,15 +75,22 @@
                     <div [ngClass]="{'text-orange-500': axe.temp > 68}">
                         {{axe.temp | number: '1.0-1'}}°<small>C</small>
                     </div>
-                    <div class="text-xs w-min" 
+                    <div class="text-sm w-min" 
                          [ngClass]="{'text-orange-500': axe.vrTemp > 90}" 
                          *ngIf="axe.vrTemp"
                          pTooltip="Voltage Regulator Temperature"
                          tooltipPosition="top">
-                        {{axe.vrTemp | number: '1.0-1'}}°C
+                        {{axe.vrTemp | number: '1.0-1'}}°<small>C</small>
                     </div>
                 </td>
-                <td>{{axe.bestDiff}}</td>
+                <td>
+                    <div>{{axe.bestDiff}}</div>
+                    <div class="text-sm w-min" 
+                         pTooltip="Best Session Diff"
+                         tooltipPosition="top">
+                        {{axe.bestSessionDiff}}
+                    </div>
+                </td>
                 <td>{{axe.version}}</td>
              <td><p-button icon="pi pi-pencil" pp-button (click)="edit(axe)"></p-button></td>
                 <td><p-button icon="pi pi-sync" pp-button severity="danger" (click)="restart(axe)"></p-button></td>

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
@@ -65,7 +65,7 @@
                 <td>{{axe.uptimeSeconds | dateAgo}}</td>
                 <td>{{axe.sharesAccepted | number: '1.0-0'}}</td>
                 <td>{{axe.power | number: '1.1-1'}} <small>W</small> </td>
-                <td [ngClass]="{'text-orange-500': axe.temp > 65}">{{axe.temp | number: '1.0-1'}}°<small>C</small></td>
+                <td [ngClass]="{'text-orange-500': axe.temp > 68}">{{axe.temp | number: '1.0-1'}}°<small>C</small></td>
                 <td>{{axe.bestDiff}}</td>
                 <td>{{axe.version}}</td>
              <td><p-button icon="pi pi-pencil" pp-button (click)="edit(axe)"></p-button></td>

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
@@ -14,13 +14,27 @@
 
     </form>
 </div>
-<div class="flex gap-3 justify-content-between">
+<div class="flex flex-column sm:flex-row gap-4 justify-content-between">
     <div class="flex gap-1 sm:gap-3 text-sm md:text-base">
         <button pButton (click)="scanNetwork()" [disabled]="scanning">{{scanning ? 'Scanning...' : 'Automatic Scan'}}</button>
         <button pButton severity="secondary" (click)="refreshList()" [disabled]="scanning || isRefreshing">
             {{isRefreshing ? 'Refreshing...' : 'Refresh List (' + refreshIntervalTime + ')'}}
         </button>
     </div>
+    <div class="flex align-items-center gap-2">
+        <label for="refresh-interval" class="text-sm md:text-base">Refresh Interval:</label>
+        <p-slider id="refresh-interval" class="pl-2 pr-2"
+                 [min]="5" 
+                 [max]="30" 
+                 [(ngModel)]="refreshTimeSet" 
+                 [style]="{'width': '150px'}"
+                 [formControl]="refreshIntervalControl">
+        </p-slider>
+        <span class="text-sm md:text-base">{{refreshTimeSet}}s</span>
+    </div>
+</div>
+
+<div class="flex justify-content-between mt-4 mb-4">
     <div class="text-sm md:text-base">
         Total Hash Rate: <span class="text-primary">{{totalHashRate * 1000000000 | hashSuffix}}</span>
     </div>

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
@@ -71,7 +71,18 @@
                 <td>{{axe.uptimeSeconds | dateAgo}}</td>
                 <td>{{axe.sharesAccepted | number: '1.0-0'}}</td>
                 <td>{{axe.power | number: '1.1-1'}} <small>W</small> </td>
-                <td [ngClass]="{'text-orange-500': axe.temp > 68}">{{axe.temp | number: '1.0-1'}}°<small>C</small></td>
+                <td>
+                    <div [ngClass]="{'text-orange-500': axe.temp > 68}">
+                        {{axe.temp | number: '1.0-1'}}°<small>C</small>
+                    </div>
+                    <div class="text-xs w-min" 
+                         [ngClass]="{'text-orange-500': axe.vrTemp > 90}" 
+                         *ngIf="axe.vrTemp"
+                         pTooltip="Voltage Regulator Temperature"
+                         tooltipPosition="top">
+                        {{axe.vrTemp | number: '1.0-1'}}°C
+                    </div>
+                </td>
                 <td>{{axe.bestDiff}}</td>
                 <td>{{axe.version}}</td>
              <td><p-button icon="pi pi-pencil" pp-button (click)="edit(axe)"></p-button></td>

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
@@ -52,7 +52,7 @@
             <th>IP</th>
             <th>Hash Rate</th>
             <th>Uptime</th>
-            <th>Accepted</th>
+            <th>Shares</th>
             <th>Power</th>
             <th>Temp</th>
             <th>Best Diff</th>
@@ -69,13 +69,24 @@
                 </td>
                 <td>{{axe.hashRate * 1000000000 | hashSuffix}}</td>
                 <td>{{axe.uptimeSeconds | dateAgo}}</td>
-                <td>{{axe.sharesAccepted | number: '1.0-0'}}</td>
+                <td>
+                    <div class="w-min cursor-pointer" 
+                         pTooltip="Shares Accepted"
+                         tooltipPosition="top">
+                        {{axe.sharesAccepted | number: '1.0-0'}}
+                    </div>
+                    <div class="text-sm w-min cursor-pointer" 
+                         pTooltip="Shares Rejected"
+                         tooltipPosition="top">
+                        {{axe.sharesRejected | number: '1.0-0'}}
+                    </div>
+                </td>
                 <td>{{axe.power | number: '1.1-1'}} <small>W</small> </td>
                 <td>
                     <div [ngClass]="{'text-orange-500': axe.temp > 68}">
                         {{axe.temp | number: '1.0-1'}}°<small>C</small>
                     </div>
-                    <div class="text-sm w-min" 
+                    <div class="text-sm w-min cursor-pointer" 
                          [ngClass]="{'text-orange-500': axe.vrTemp > 90}" 
                          *ngIf="axe.vrTemp"
                          pTooltip="Voltage Regulator Temperature"
@@ -85,7 +96,7 @@
                 </td>
                 <td>
                     <div>{{axe.bestDiff}}</div>
-                    <div class="text-sm w-min" 
+                    <div class="text-sm w-min cursor-pointer" 
                          pTooltip="Best Session Diff"
                          tooltipPosition="top">
                         {{axe.bestSessionDiff}}

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.scss
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.scss
@@ -1,11 +1,5 @@
-// form {
-//     margin-bottom: 20px;
-// }
-
 table {
     width: 100%;
-    margin-top: 40px;
-    margin-bottom: 40px;
     border: 1px solid #304562;
 }
 
@@ -57,7 +51,7 @@ a {
 .table-container {
     width: 100%;
     overflow-x: auto;
-    margin: 1rem 0;
+    margin: 0;
     
     table {
         min-width: 100%;

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.scss
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.scss
@@ -1,6 +1,6 @@
-form {
-    margin-bottom: 20px;
-}
+// form {
+//     margin-bottom: 20px;
+// }
 
 table {
     width: 100%;

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -52,7 +52,7 @@ export class SwarmComponent implements OnInit, OnDestroy {
       //this.swarm$ = this.scanNetwork('192.168.1.23', '255.255.255.0').pipe(take(1));
     } else {
       this.swarm = swarmData;
-      this.calculateTotalHashRate();
+      this.refreshList();
     }
 
     this.refreshIntervalRef = window.setInterval(() => {

--- a/main/http_server/axe-os/src/app/local-storage.service.ts
+++ b/main/http_server/axe-os/src/app/local-storage.service.ts
@@ -34,4 +34,13 @@ export class LocalStorageService {
     }
     return JSON.parse(item);
   }
+
+  setNumber(key: string, value: number) {
+    localStorage.setItem(key, value.toString());
+  }
+
+  getNumber(key: string): number | null {
+    const value = localStorage.getItem(key);
+    return value ? Number(value) : null;
+  }
 }


### PR DESCRIPTION
## Description

Some more tweaks for the swarm page
- Decrease the white space around the manual swarm add
- When the page is loaded it should refresh the data right away
- Allow the user to set the refresh interval
- Increase the temp threshold for the temp warning color
- Have total hash on its own line and adjust spacing there