### PR TITLE
Fix stratum message order

### DIFF
--- a/components/stratum/include/stratum_api.h
+++ b/components/stratum/include/stratum_api.h
@@ -23,8 +23,8 @@ typedef enum
     CLIENT_RECONNECT
 } stratum_method;
 
-static const int  STRATUM_ID_SUBSCRIBE    = 1;
-static const int  STRATUM_ID_CONFIGURE    = 2;
+static const int  STRATUM_ID_CONFIGURE    = 1;
+static const int  STRATUM_ID_SUBSCRIBE    = 2;
 
 typedef struct
 {

--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -236,11 +236,11 @@ void stratum_task(void * pvParameters)
         cleanQueue(GLOBAL_STATE);
 
         ///// Start Stratum Action
-        // mining.subscribe - ID: 1
-        STRATUM_V1_subscribe(GLOBAL_STATE->sock, GLOBAL_STATE->asic_model_str);
-
-        // mining.configure - ID: 2
+        // mining.configure - ID: 1
         STRATUM_V1_configure_version_rolling(GLOBAL_STATE->sock, &GLOBAL_STATE->version_mask);
+
+        // mining.subscribe - ID: 2
+        STRATUM_V1_subscribe(GLOBAL_STATE->sock, GLOBAL_STATE->asic_model_str);
 
         char * username = GLOBAL_STATE->SYSTEM_MODULE.is_using_fallback ? nvs_config_get_string(NVS_CONFIG_FALLBACK_STRATUM_USER, FALLBACK_STRATUM_USER) : nvs_config_get_string(NVS_CONFIG_STRATUM_USER, STRATUM_USER);
         char * password = GLOBAL_STATE->SYSTEM_MODULE.is_using_fallback ? nvs_config_get_string(NVS_CONFIG_FALLBACK_STRATUM_PASS, FALLBACK_STRATUM_PW) : nvs_config_get_string(NVS_CONFIG_STRATUM_PASS, STRATUM_PW);


### PR DESCRIPTION
Missing TODO from #84, it should start with `mining.configure`.