### PR TITLE
Fix bug when setting baudrate that can prevent the ASIC from working

### DIFF
--- a/components/asic/serial.c
+++ b/components/asic/serial.c
@@ -46,6 +46,10 @@ void SERIAL_init(void)
 void SERIAL_set_baud(int baud)
 {
     ESP_LOGI(TAG, "Changing UART baud to %i", baud);
+
+    // Make sure that we are done writing before setting a new baudrate.
+    uart_wait_tx_done(UART_NUM_1, 1000 / portTICK_PERIOD_MS);
+
     uart_set_baudrate(UART_NUM_1, baud);
 }
 


### PR DESCRIPTION
When setting the baud rate, we need to ensure that all serial communication is transmitted; otherwise, the ASIC may not be initialized properly. As a result, the device would be unable to hash anything until the next reboot.

The easiest way to reproduce this issue is by disabling logging. However, it can occur with any device at any time due to a bit of bad luck during startup.
```
diff --git a/main/main.c b/main/main.c
index dbc467b..8e7fb4e 100644
--- a/main/main.c
+++ b/main/main.c
@@ -35,6 +35,8 @@ void app_main(void)
 {
     ESP_LOGI(TAG, "Welcome to the bitaxe - hack the planet!");
 
+    esp_log_level_set("*", ESP_LOG_WARN);
+
     // Init I2C
     ESP_ERROR_CHECK(i2c_bitaxe_init());
     ESP_LOGI(TAG, "I2C initialized successfully");
```