### PR TITLE
Button press cleanup

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -21,7 +21,6 @@ SRCS
     "./tasks/create_jobs_task.c"
     "./tasks/asic_task.c"
     "./tasks/asic_result_task.c"
-    "./tasks/user_input_task.c"
     "./tasks/power_management_task.c"
 
 INCLUDE_DIRS

--- a/main/main.c
+++ b/main/main.c
@@ -15,7 +15,7 @@
 #include "nvs_config.h"
 #include "serial.h"
 #include "stratum_task.h"
-#include "user_input_task.h"
+//#include "user_input_task.h"
 #include "i2c_bitaxe.h"
 #include "adc.h"
 #include "nvs_device.h"
@@ -116,7 +116,7 @@ void app_main(void)
     GLOBAL_STATE.SYSTEM_MODULE.startup_done = true;
     GLOBAL_STATE.new_stratum_version_rolling_msg = false;
 
-    xTaskCreate(USER_INPUT_task, "user input", 8192, (void *) &GLOBAL_STATE, 5, NULL);
+    //xTaskCreate(USER_INPUT_task, "user input", 8192, (void *) &GLOBAL_STATE, 5, NULL);
 
     if (GLOBAL_STATE.ASIC_functions.init_fn != NULL) {
         wifi_softap_off();

--- a/main/system.c
+++ b/main/system.c
@@ -254,6 +254,7 @@ void SYSTEM_task(void * pvParameters)
         vTaskSuspend(NULL);
     }
 
+    _clear_display(GLOBAL_STATE);
     _update_screen_one(GLOBAL_STATE);
 
     configure_button_boot_interrupt();


### PR DESCRIPTION
looking at the button handling code after @ACSBEN noticed #506 I found a way to optimize it.

Now it uses interrupt for the button presses, and a timer to determine if it's a long press or not. The regular display update interval is an event group now, and it can be interrupted by a BUTTON_PRESS event.