### PR TITLE
Fix Save settings button

### DIFF
--- a/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.html
+++ b/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.html
@@ -26,7 +26,7 @@
         </div>
 
         <div class="mt-2">
-            <button pButton [disabled]="!form.dirty || form.invalid" (click)="updateSystem()"
+            <button pButton [disabled]="!form.dirty || !form.invalid" (click)="updateSystem()"
                 class="btn btn-primary mr-2">Save</button>
             <b style="line-height: 34px;">You must restart this device after saving for changes to take effect.</b>
         </div>


### PR DESCRIPTION
I found an error in the updated OS where you can't actually click the `Save` button after changing any of the configs. Now, I'm not a frontend dev, so I could be quite wrong in this being the actual fix; however, _I have verified a fix by manually setting the `disabled` flag to `enabled` in the browser inspector_. The proposed change is an assumption that considering the **pending** form state will fix the issue.

![broken_axe_setting](https://github.com/user-attachments/assets/80702b06-cff8-4655-bf16-643210eb5023)
![fixed_axe_setting](https://github.com/user-attachments/assets/8c2107b5-c76e-4b2c-bf68-579a975b0912)
