### PR TITLE
fix: reboot after www.bin update

### DIFF
--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -496,7 +496,11 @@ esp_err_t POST_WWW_update(httpd_req_t * req)
         remaining -= recv_len;
     }
 
-    httpd_resp_sendstr(req, "WWW update complete\n");
+    httpd_resp_sendstr(req, "WWW update complete, rebooting now!\n");
+    ESP_LOGI(TAG, "Restarting system after WWW update complete");
+    vTaskDelay(1000 / portTICK_PERIOD_MS);
+    esp_restart();
+
     return ESP_OK;
 }
 


### PR DESCRIPTION
Currently, automatic reboot of the ESP32 occurs after successful `esp-miner.bin` update, but not on successful `www.bin` update. This change ensures `www.bin` updates also induce reboot.

#519 documents an issue with feedback provided in the web UI during update, and potential page reload.

Opening as draft for now, since it may not be strictly necessary to reboot on `www` overwrite, depending on spiffs management approach.