### PR TITLE
test: fix failing unit test for large stratum id

### DIFF
--- a/components/stratum/test/test_stratum_json.c
+++ b/components/stratum/test/test_stratum_json.c
@@ -130,7 +130,7 @@ TEST_CASE("Parse stratum result success with large id", "[stratum]")
     StratumApiV1Message stratum_api_v1_message = {};
     const char *json_string = "{\"id\":32769,\"error\":null,\"result\":true}";
     STRATUM_V1_parse(&stratum_api_v1_message, json_string);
-    TEST_ASSERT_EQUAL(32768, stratum_api_v1_message.message_id);
+    TEST_ASSERT_EQUAL(32769, stratum_api_v1_message.message_id);
     TEST_ASSERT_EQUAL(STRATUM_RESULT, stratum_api_v1_message.method);
     TEST_ASSERT_TRUE(stratum_api_v1_message.response_success);
 }


### PR DESCRIPTION
PR #243 changes the type of id to int64_t, allowing for ids exceeding a 16-bit integer.
This adjusts an associated unit test to ensure that 16-bit rollover doesn't occur.

After flashing with `unit_test_stratum.bin`, observed the test passing now:

```
Running Parse stratum result success with large id...
/home/dev/myrepos/ESP-Miner/components/stratum/test/test_stratum_json.c:128:Parse stratum result success with large id:PASS
Running Parse stratum result success with larger id...
/home/dev/myrepos/ESP-Miner/components/stratum/test/test_stratum_json.c:138:Parse stratum result success with larger id:PASS
```