### PR TITLE
test: add boundary check for implicit response method

### DIFF
--- a/components/stratum/test/test_stratum_json.c
+++ b/components/stratum/test/test_stratum_json.c
@@ -117,10 +117,17 @@ TEST_CASE("Parse stratum mining.set_version_mask params", "[stratum]")
 
 TEST_CASE("Parse stratum result success", "[stratum]")
 {
+    StratumApiV1Message stratum_api_v1_setup_message = {};
+    const char* resp1 = "{\"id\":4,\"error\":null,\"result\":true}";
+    STRATUM_V1_parse(&stratum_api_v1_setup_message, resp1);
+    TEST_ASSERT_EQUAL(4, stratum_api_v1_setup_message.message_id);
+    TEST_ASSERT_EQUAL(STRATUM_RESULT_SETUP, stratum_api_v1_setup_message.method);
+    TEST_ASSERT_TRUE(stratum_api_v1_setup_message.response_success);
+
     StratumApiV1Message stratum_api_v1_message = {};
-    const char *json_string = "{\"id\":1,\"error\":null,\"result\":true}";
+    const char* json_string = "{\"id\":5,\"error\":null,\"result\":true}";
     STRATUM_V1_parse(&stratum_api_v1_message, json_string);
-    TEST_ASSERT_EQUAL(1, stratum_api_v1_message.message_id);
+    TEST_ASSERT_EQUAL(5, stratum_api_v1_message.message_id);
     TEST_ASSERT_EQUAL(STRATUM_RESULT, stratum_api_v1_message.method);
     TEST_ASSERT_TRUE(stratum_api_v1_message.response_success);
 }
@@ -147,13 +154,21 @@ TEST_CASE("Parse stratum result success with larger id", "[stratum]")
 
 TEST_CASE("Parse stratum result error", "[stratum]")
 {
+    StratumApiV1Message stratum_api_v1_setup_message = {};
+    const char* resp1 = "{\"id\":4,\"result\":null,\"error\":[21,\"Job not found\",\"\"]}";
+    STRATUM_V1_parse(&stratum_api_v1_setup_message, resp1);
+    TEST_ASSERT_EQUAL(4, stratum_api_v1_setup_message.message_id);
+    TEST_ASSERT_EQUAL(STRATUM_RESULT_SETUP, stratum_api_v1_setup_message.method);
+    TEST_ASSERT_FALSE(stratum_api_v1_setup_message.response_success);
+    TEST_ASSERT_EQUAL_STRING("Job not found", stratum_api_v1_setup_message.error_str);
+
     StratumApiV1Message stratum_api_v1_message = {};
-    const char *json_string = "{\"id\":1,\"result\":null,\"error\":[21,\"Job not found\",\"\"]}";
+    const char* json_string = "{\"id\":5,\"result\":null,\"error\":[21,\"Job not found\",\"\"]}";
     STRATUM_V1_parse(&stratum_api_v1_message, json_string);
-    TEST_ASSERT_EQUAL(1, stratum_api_v1_message.message_id);
+    TEST_ASSERT_EQUAL(5, stratum_api_v1_message.message_id);
     TEST_ASSERT_EQUAL(STRATUM_RESULT, stratum_api_v1_message.method);
     TEST_ASSERT_FALSE(stratum_api_v1_message.response_success);
-    TEST_ASSERT_EQUAL("Job not found", stratum_api_v1_message.error_str);
+    TEST_ASSERT_EQUAL_STRING("Job not found", stratum_api_v1_message.error_str);
 }
 
 TEST_CASE("Parse stratum result alternative error", "[stratum]")


### PR DESCRIPTION
Looks like #192 introduced changes to the `stratum_method` enum that causes failures in the unit tests added a week prior in #163. This PR adjusts adjusts the tests and makes them more descriptive to test the boundary condition in 

https://github.com/skot/ESP-Miner/blob/468718abda12979e34e6da8981a6976193ccf48b/components/stratum/stratum_api.c#L155-L169

Tested by flashing `unit_test_stratum.bin` and monitoring test logging:

```
Running Parse stratum result success...
/home/dev/myrepos/ESP-Miner/components/stratum/test/test_stratum_json.c:118:Parse stratum result success:PASS
...
Running Parse stratum result error...
/home/dev/myrepos/ESP-Miner/components/stratum/test/test_stratum_json.c:155:Parse stratum result error:PASS
```