### PR TITLE
fix: Swarm hashRate check, shorter uptime, & pause refresh on scan

### DIFF
--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
@@ -26,7 +26,6 @@
         <p-slider id="refresh-interval" class="pl-2 pr-2"
                  [min]="5" 
                  [max]="30" 
-                 [(ngModel)]="refreshTimeSet" 
                  [style]="{'width': '150px'}"
                  [formControl]="refreshIntervalControl">
         </p-slider>
@@ -68,7 +67,7 @@
                     <div class="text-sm">{{axe.hostname}}</div>
                 </td>
                 <td>{{axe.hashRate * 1000000000 | hashSuffix}}</td>
-                <td>{{axe.uptimeSeconds | dateAgo}}</td>
+                <td>{{axe.uptimeSeconds | dateAgo: {intervals: 2} }}</td>
                 <td>
                     <div class="w-min cursor-pointer" 
                          pTooltip="Shares Accepted"

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -63,14 +63,13 @@ export class SwarmComponent implements OnInit, OnDestroy {
 
     if (swarmData == null) {
       this.scanNetwork();
-      //this.swarm$ = this.scanNetwork('192.168.1.23', '255.255.255.0').pipe(take(1));
     } else {
       this.swarm = swarmData;
       this.refreshList();
     }
 
     this.refreshIntervalRef = window.setInterval(() => {
-      if (!this.isRefreshing) {
+      if (!this.scanning && !this.isRefreshing) {
         this.refreshIntervalTime--;
         if (this.refreshIntervalTime <= 0) {
           this.refreshList();
@@ -83,8 +82,6 @@ export class SwarmComponent implements OnInit, OnDestroy {
     window.clearInterval(this.refreshIntervalRef);
     this.form.reset();
   }
-
-
 
   private ipToInt(ip: string): number {
     return ip.split('.').reduce((acc, octet) => (acc << 8) + parseInt(octet, 10), 0) >>> 0;
@@ -189,6 +186,10 @@ export class SwarmComponent implements OnInit, OnDestroy {
   }
 
   public refreshList() {
+    if (this.scanning) {
+      return;
+    }
+    
     this.refreshIntervalTime = this.refreshTimeSet;
     const ips = this.swarm.map(axeOs => axeOs.IP);
     this.isRefreshing = true;

--- a/main/http_server/axe-os/src/app/pipes/date-ago.pipe.ts
+++ b/main/http_server/axe-os/src/app/pipes/date-ago.pipe.ts
@@ -22,9 +22,11 @@ export class DateAgoPipe implements PipeTransform {
         'second': 1
       };
       let result = '';
+      let shownIntervals = 0;
       for (const i in intervals) {
+        if (args?.intervals && shownIntervals >= args.intervals) break;
         const counter = Math.floor(seconds / intervals[i]);
-        if (counter > 0)
+        if (counter > 0) {
           if (counter === 1) {
             if (result) result += ', '
             result += counter + ' ' + i + ''; // singular (1 day ago)
@@ -34,6 +36,8 @@ export class DateAgoPipe implements PipeTransform {
             result += counter + ' ' + i + 's'; // plural (2 days ago)
             seconds -= intervals[i] * counter
           }
+          shownIntervals++;
+        }
       }
       return result;
     }


### PR DESCRIPTION
## Description

- On a swarm scan, only add devices that have the hashRate property to prevent devices like the Philips Hue hub from trying to get added that has the same endpoint
- Allow shorter date ago pipe and use it on the swarm page so the columns don't get too long
- Prevent swarm refreshes during scans