### PR TITLE
Add ESP-IDF version to overview

### DIFF
--- a/main/http_server/axe-os/src/app/components/logs/logs.component.html
+++ b/main/http_server/axe-os/src/app/components/logs/logs.component.html
@@ -28,6 +28,10 @@
                     <td>{{info.version}}</td>
                 </tr>
                 <tr>
+                    <td>ESP-IDF Version:</td>
+                    <td>{{info.idfVersion}}</td>
+                </tr>
+                <tr>
                     <td>Board Version:</td>
                     <td>{{info.boardVersion}}</td>
                 </tr>

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -52,6 +52,7 @@ export class SystemService {
           isUsingFallbackStratum: true,
           frequency: 485,
           version: "2.0",
+          idfVersion: "v5.1.2",
           boardVersion: "204",
           flipscreen: 1,
           invertscreen: 0,

--- a/main/http_server/axe-os/src/models/ISystemInfo.ts
+++ b/main/http_server/axe-os/src/models/ISystemInfo.ts
@@ -33,6 +33,7 @@ export interface ISystemInfo {
     fallbackStratumUser: string,
     frequency: number,
     version: string,
+    idfVersion: string,
     boardVersion: string,
     invertfanpolarity: number,
     autofanspeed: number,

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -422,6 +422,7 @@ static esp_err_t GET_system_info(httpd_req_t * req)
     cJSON_AddStringToObject(root, "fallbackStratumUser", fallbackStratumUser);
 
     cJSON_AddStringToObject(root, "version", esp_app_get_description()->version);
+    cJSON_AddStringToObject(root, "idfVersion", esp_get_idf_version());
     cJSON_AddStringToObject(root, "boardVersion", board_version);
     cJSON_AddStringToObject(root, "runningPartition", esp_ota_get_running_partition()->label);
 


### PR DESCRIPTION
This is to help us better understand the version of ESP-IDF version used when troubleshooting issues (e.g. SPIRAM working, or not working).