### PR TITLE
Move more components to SPIRAM

### DIFF
--- a/components/asic/bm1366.c
+++ b/components/asic/bm1366.c
@@ -75,7 +75,7 @@ static void _send_BM1366(uint8_t header, uint8_t * data, uint8_t data_len, bool 
     uint8_t total_length = (packet_type == JOB_PACKET) ? (data_len + 6) : (data_len + 5);
 
     // allocate memory for buffer
-    unsigned char * buf = malloc(total_length);
+    unsigned char * buf = heap_caps_malloc(total_length, MALLOC_CAP_SPIRAM);
 
     // add the preamble
     buf[0] = 0x55;
@@ -107,7 +107,7 @@ static void _send_BM1366(uint8_t header, uint8_t * data, uint8_t data_len, bool 
 
 static void _send_simple(uint8_t * data, uint8_t total_length)
 {
-    unsigned char * buf = malloc(total_length);
+    unsigned char * buf = heap_caps_malloc(total_length, MALLOC_CAP_SPIRAM);
     memcpy(buf, data, total_length);
     SERIAL_send(buf, total_length, BM1366_SERIALTX_DEBUG);
 

--- a/components/asic/bm1368.c
+++ b/components/asic/bm1368.c
@@ -69,7 +69,7 @@ static void _send_BM1368(uint8_t header, uint8_t * data, uint8_t data_len, bool 
     packet_type_t packet_type = (header & TYPE_JOB) ? JOB_PACKET : CMD_PACKET;
     uint8_t total_length = (packet_type == JOB_PACKET) ? (data_len + 6) : (data_len + 5);
 
-    unsigned char * buf = malloc(total_length);
+    unsigned char * buf = heap_caps_malloc(total_length, MALLOC_CAP_SPIRAM);
 
     buf[0] = 0x55;
     buf[1] = 0xAA;
@@ -92,7 +92,7 @@ static void _send_BM1368(uint8_t header, uint8_t * data, uint8_t data_len, bool 
 
 static void _send_simple(uint8_t * data, uint8_t total_length)
 {
-    unsigned char * buf = malloc(total_length);
+    unsigned char * buf = heap_caps_malloc(total_length, MALLOC_CAP_SPIRAM);
     memcpy(buf, data, total_length);
     SERIAL_send(buf, total_length, BM1368_SERIALTX_DEBUG);
 

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -75,7 +75,7 @@ static void _send_BM1370(uint8_t header, uint8_t * data, uint8_t data_len, bool 
     uint8_t total_length = (packet_type == JOB_PACKET) ? (data_len + 6) : (data_len + 5);
 
     // allocate memory for buffer
-    unsigned char * buf = malloc(total_length);
+    unsigned char * buf = heap_caps_malloc(total_length, MALLOC_CAP_SPIRAM);
 
     // add the preamble
     buf[0] = 0x55;
@@ -109,7 +109,7 @@ static void _send_BM1370(uint8_t header, uint8_t * data, uint8_t data_len, bool 
 
 static void _send_simple(uint8_t * data, uint8_t total_length)
 {
-    unsigned char * buf = malloc(total_length);
+    unsigned char * buf = heap_caps_malloc(total_length, MALLOC_CAP_SPIRAM);
     memcpy(buf, data, total_length);
     SERIAL_send(buf, total_length, BM1370_SERIALTX_DEBUG);
 

--- a/components/asic/bm1397.c
+++ b/components/asic/bm1397.c
@@ -74,7 +74,7 @@ static void _send_BM1397(uint8_t header, uint8_t *data, uint8_t data_len, bool d
     uint8_t total_length = (packet_type == JOB_PACKET) ? (data_len + 6) : (data_len + 5);
 
     // allocate memory for buffer
-    unsigned char *buf = malloc(total_length);
+    unsigned char *buf = heap_caps_malloc(total_length, MALLOC_CAP_SPIRAM);
 
     // add the preamble
     buf[0] = 0x55;

--- a/components/stratum/mining.c
+++ b/components/stratum/mining.c
@@ -3,6 +3,8 @@
 #include <limits.h>
 #include "mining.h"
 #include "utils.h"
+
+#include "freertos/FreeRTOS.h"
 #include "mbedtls/sha256.h"
 
 void free_bm_job(bm_job *job)
@@ -17,7 +19,7 @@ char *construct_coinbase_tx(const char *coinbase_1, const char *coinbase_2,
 {
     int coinbase_tx_len = strlen(coinbase_1) + strlen(coinbase_2) + strlen(extranonce) + strlen(extranonce_2) + 1;
 
-    char *coinbase_tx = malloc(coinbase_tx_len);
+    char *coinbase_tx = heap_caps_malloc(coinbase_tx_len, MALLOC_CAP_SPIRAM);
     strcpy(coinbase_tx, coinbase_1);
     strcat(coinbase_tx, extranonce);
     strcat(coinbase_tx, extranonce_2);
@@ -30,7 +32,7 @@ char *construct_coinbase_tx(const char *coinbase_1, const char *coinbase_2,
 char *calculate_merkle_root_hash(const char *coinbase_tx, const uint8_t merkle_branches[][32], const int num_merkle_branches)
 {
     size_t coinbase_tx_bin_len = strlen(coinbase_tx) / 2;
-    uint8_t *coinbase_tx_bin = malloc(coinbase_tx_bin_len);
+    uint8_t *coinbase_tx_bin = heap_caps_malloc(coinbase_tx_bin_len, MALLOC_CAP_SPIRAM);
     hex2bin(coinbase_tx, coinbase_tx_bin, coinbase_tx_bin_len);
 
     uint8_t both_merkles[64];
@@ -46,7 +48,7 @@ char *calculate_merkle_root_hash(const char *coinbase_tx, const uint8_t merkle_b
         free(new_root);
     }
 
-    char *merkle_root_hash = malloc(65);
+    char *merkle_root_hash = heap_caps_malloc(65, MALLOC_CAP_SPIRAM);
     bin2hex(both_merkles, 32, merkle_root_hash, 65);
     return merkle_root_hash;
 }
@@ -112,7 +114,7 @@ bm_job construct_bm_job(mining_notify *params, const char *merkle_root, const ui
 
 char *extranonce_2_generate(uint32_t extranonce_2, uint32_t length)
 {
-    char *extranonce_2_str = malloc(length * 2 + 1);
+    char *extranonce_2_str = heap_caps_malloc(length * 2 + 1, MALLOC_CAP_SPIRAM);
     memset(extranonce_2_str, '0', length * 2);
     extranonce_2_str[length * 2] = '\0';
     bin2hex((uint8_t *)&extranonce_2, sizeof(extranonce_2), extranonce_2_str, length * 2 + 1);

--- a/components/stratum/stratum_api.c
+++ b/components/stratum/stratum_api.c
@@ -35,7 +35,7 @@ void STRATUM_V1_reset_uid()
 
 void STRATUM_V1_initialize_buffer()
 {
-    json_rpc_buffer = malloc(BUFFER_SIZE);
+    json_rpc_buffer = heap_caps_malloc(BUFFER_SIZE, MALLOC_CAP_SPIRAM);
     json_rpc_buffer_size = BUFFER_SIZE;
     if (json_rpc_buffer == NULL) {
         printf("Error: Failed to allocate memory for buffer\n");
@@ -204,7 +204,7 @@ void STRATUM_V1_parse(StratumApiV1Message * message, const char * stratum_json)
                 message->response_success = false;
                 goto done;
             }
-            message->extranonce_str = malloc(strlen(extranonce_json->valuestring) + 1);
+            message->extranonce_str = heap_caps_malloc(strlen(extranonce_json->valuestring) + 1, MALLOC_CAP_SPIRAM);
             strcpy(message->extranonce_str, extranonce_json->valuestring);
             message->response_success = true;
 
@@ -232,7 +232,7 @@ void STRATUM_V1_parse(StratumApiV1Message * message, const char * stratum_json)
 
     if (message->method == MINING_NOTIFY) {
 
-        mining_notify * new_work = malloc(sizeof(mining_notify));
+        mining_notify * new_work = heap_caps_malloc(sizeof(mining_notify), MALLOC_CAP_SPIRAM);
         // new_work->difficulty = difficulty;
         cJSON * params = cJSON_GetObjectItem(json, "params");
         new_work->job_id = strdup(cJSON_GetArrayItem(params, 0)->valuestring);
@@ -246,7 +246,7 @@ void STRATUM_V1_parse(StratumApiV1Message * message, const char * stratum_json)
             printf("Too many Merkle branches.\n");
             abort();
         }
-        new_work->merkle_branches = malloc(HASH_SIZE * new_work->n_merkle_branches);
+        new_work->merkle_branches = heap_caps_malloc(HASH_SIZE * new_work->n_merkle_branches, MALLOC_CAP_SPIRAM);
         for (size_t i = 0; i < new_work->n_merkle_branches; i++) {
             hex2bin(cJSON_GetArrayItem(merkle_branch, i)->valuestring, new_work->merkle_branches + HASH_SIZE * i, HASH_SIZE);
         }
@@ -311,7 +311,7 @@ int _parse_stratum_subscribe_result_message(const char * result_json_str, char *
         ESP_LOGE(TAG, "Unable parse extranonce: %s", result->valuestring);
         return -1;
     }
-    *extranonce = malloc(strlen(extranonce_json->valuestring) + 1);
+    *extranonce = heap_caps_malloc(strlen(extranonce_json->valuestring) + 1, MALLOC_CAP_SPIRAM);
     strcpy(*extranonce, extranonce_json->valuestring);
 
     cJSON_Delete(root);

--- a/components/stratum/test/test_utils.c
+++ b/components/stratum/test/test_utils.c
@@ -13,7 +13,7 @@ TEST_CASE("Test hex2bin", "[utils]")
 {
     char *hex_string = "48454c4c4f";
     size_t bin_len = strlen(hex_string) / 2;
-    uint8_t *bin = malloc(bin_len);
+    uint8_t *bin = heap_caps_malloc(bin_len, MALLOC_CAP_SPIRAM);
     hex2bin(hex_string, bin, bin_len);
     TEST_ASSERT_EQUAL(72, bin[0]);
     TEST_ASSERT_EQUAL(69, bin[1]);

--- a/components/stratum/utils.c
+++ b/components/stratum/utils.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <stdio.h>
 
+#include "freertos/FreeRTOS.h"
 #include "mbedtls/sha256.h"
 
 #ifndef bswap_16
@@ -168,7 +169,7 @@ void print_hex(const uint8_t *b, size_t len,
 char *double_sha256(const char *hex_string)
 {
     size_t bin_len = strlen(hex_string) / 2;
-    uint8_t *bin = malloc(bin_len);
+    uint8_t *bin = heap_caps_malloc(bin_len, MALLOC_CAP_SPIRAM);
     hex2bin(hex_string, bin, bin_len);
 
     unsigned char first_hash_output[32], second_hash_output[32];
@@ -178,7 +179,7 @@ char *double_sha256(const char *hex_string)
 
     free(bin);
 
-    char *output_hash = malloc(64 + 1);
+    char *output_hash = heap_caps_malloc(64 + 1, MALLOC_CAP_SPIRAM);
     bin2hex(second_hash_output, 32, output_hash, 65);
     return output_hash;
 }
@@ -186,7 +187,7 @@ char *double_sha256(const char *hex_string)
 uint8_t *double_sha256_bin(const uint8_t *data, const size_t data_len)
 {
     uint8_t first_hash_output[32];
-    uint8_t *second_hash_output = malloc(32);
+    uint8_t *second_hash_output = heap_caps_malloc(43, MALLOC_CAP_SPIRAM);
 
     mbedtls_sha256(data, data_len, first_hash_output, 0);
     mbedtls_sha256(first_hash_output, 32, second_hash_output, 0);


### PR DESCRIPTION
Make sure all mining and asic related tasks are all stored on the SPIRAM, leaving more for system resources on main memory.