### PR TITLE
Grandma knows what Wifi means!

### DIFF
--- a/components/connect/connect.c
+++ b/components/connect/connect.c
@@ -224,27 +224,41 @@ void wifi_init(const char * wifi_ssid, const char * wifi_pass, const char * host
     ESP_LOGI(TAG, "ESP_WIFI Access Point On");
     wifi_init_softap();
 
-    /* Initialize STA */
-    ESP_LOGI(TAG, "ESP_WIFI_MODE_STA");
-    esp_netif_t * esp_netif_sta = wifi_init_sta(wifi_ssid, wifi_pass);
 
-    /* Start WiFi */
-    ESP_ERROR_CHECK(esp_wifi_start());
+    /* Skip connection if SSID is null */
+    if (strlen(wifi_ssid) == 0) {
+        ESP_LOGI(TAG, "No WiFi SSID provided, skipping connection");
 
-    /* Disable power savings for best performance */
-    ESP_ERROR_CHECK(esp_wifi_set_ps(WIFI_PS_NONE));
+        /* Start WiFi */
+        ESP_ERROR_CHECK(esp_wifi_start());
 
-    /* Set Hostname */
-    esp_err_t err = esp_netif_set_hostname(esp_netif_sta, hostname);
-    if (err != ERR_OK) {
-        ESP_LOGW(TAG, "esp_netif_set_hostname failed: %s", esp_err_to_name(err));
+        /* Disable power savings for best performance */
+        ESP_ERROR_CHECK(esp_wifi_set_ps(WIFI_PS_NONE));
+
+        return;
     } else {
-        ESP_LOGI(TAG, "ESP_WIFI setting hostname to: %s", hostname);
+        /* Initialize STA */
+        ESP_LOGI(TAG, "ESP_WIFI_MODE_STA");
+        esp_netif_t * esp_netif_sta = wifi_init_sta(wifi_ssid, wifi_pass);
+
+        /* Start WiFi */
+        ESP_ERROR_CHECK(esp_wifi_start());
+
+        /* Disable power savings for best performance */
+        ESP_ERROR_CHECK(esp_wifi_set_ps(WIFI_PS_NONE));
+
+        /* Set Hostname */
+        esp_err_t err = esp_netif_set_hostname(esp_netif_sta, hostname);
+        if (err != ERR_OK) {
+            ESP_LOGW(TAG, "esp_netif_set_hostname failed: %s", esp_err_to_name(err));
+        } else {
+            ESP_LOGI(TAG, "ESP_WIFI setting hostname to: %s", hostname);
+        }
+
+        ESP_LOGI(TAG, "wifi_init_sta finished.");
+
+        return;
     }
-
-    ESP_LOGI(TAG, "wifi_init_sta finished.");
-
-    return;
 }
 
 EventBits_t wifi_connect(void)

--- a/components/connect/connect.c
+++ b/components/connect/connect.c
@@ -74,7 +74,7 @@ static void event_handler(void * arg, esp_event_base_t event_base, int32_t event
         vTaskDelay(2500 / portTICK_PERIOD_MS);
         esp_wifi_connect();
         s_retry_num++;
-        ESP_LOGI(TAG, "Retrying WiFi connection...");
+        ESP_LOGI(TAG, "Retrying Wi-Fi connection...");
         MINER_set_wifi_status(WIFI_RETRYING, s_retry_num, event->reason);
 
     } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
@@ -160,10 +160,10 @@ esp_netif_t * wifi_init_sta(const char * wifi_ssid, const char * wifi_pass)
     wifi_auth_mode_t authmode;
 
     if (strlen(wifi_pass) == 0) {
-        ESP_LOGI(TAG, "No WiFi password provided, using open network");
+        ESP_LOGI(TAG, "No Wi-Fi password provided, using open network");
         authmode = WIFI_AUTH_OPEN;
     } else {
-        ESP_LOGI(TAG, "WiFi Password provided, using WPA2");
+        ESP_LOGI(TAG, "Wi-Fi Password provided, using WPA2");
         authmode = WIFI_AUTH_WPA2_PSK;
     }
 
@@ -214,7 +214,7 @@ void wifi_init(const char * wifi_ssid, const char * wifi_pass, const char * host
     ESP_ERROR_CHECK(esp_event_handler_instance_register(WIFI_EVENT, ESP_EVENT_ANY_ID, &event_handler, NULL, &instance_any_id));
     ESP_ERROR_CHECK(esp_event_handler_instance_register(IP_EVENT, IP_EVENT_STA_GOT_IP, &event_handler, NULL, &instance_got_ip));
 
-    /*Initialize WiFi */
+    /* Initialize Wi-Fi */
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
     ESP_ERROR_CHECK(esp_wifi_init(&cfg));
 
@@ -241,7 +241,7 @@ void wifi_init(const char * wifi_ssid, const char * wifi_pass, const char * host
         ESP_LOGI(TAG, "ESP_WIFI_MODE_STA");
         esp_netif_t * esp_netif_sta = wifi_init_sta(wifi_ssid, wifi_pass);
 
-        /* Start WiFi */
+        /* Start Wi-Fi */
         ESP_ERROR_CHECK(esp_wifi_start());
 
         /* Disable power savings for best performance */

--- a/config-102.cvs
+++ b/config-102.cvs
@@ -1,8 +1,8 @@
 key,type,encoding,value
 main,namespace,,
 hostname,data,string,bitaxe
-wifissid,data,string,myssid
-wifipass,data,string,password
+wifissid,data,string,
+wifipass,data,string,
 stratumurl,data,string,public-pool.io
 stratumport,data,u16,21496
 stratumuser,data,string,bc1qnp980s5fpp8l94p5cvttmtdqy8rvrq74qly2yrfmzkdsntqzlc5qkc4rkq.bitaxe

--- a/config-201.cvs
+++ b/config-201.cvs
@@ -1,8 +1,8 @@
 key,type,encoding,value
 main,namespace,,
 hostname,data,string,bitaxe
-wifissid,data,string,myssid
-wifipass,data,string,password
+wifissid,data,string,
+wifipass,data,string,
 stratumurl,data,string,public-pool.io
 stratumport,data,u16,21496
 stratumuser,data,string,bc1qnp980s5fpp8l94p5cvttmtdqy8rvrq74qly2yrfmzkdsntqzlc5qkc4rkq.bitaxe

--- a/config-202.cvs
+++ b/config-202.cvs
@@ -1,8 +1,8 @@
 key,type,encoding,value
 main,namespace,,
 hostname,data,string,bitaxe
-wifissid,data,string,myssid
-wifipass,data,string,password
+wifissid,data,string,
+wifipass,data,string,
 stratumurl,data,string,public-pool.io
 stratumport,data,u16,21496
 stratumuser,data,string,bc1qnp980s5fpp8l94p5cvttmtdqy8rvrq74qly2yrfmzkdsntqzlc5qkc4rkq.bitaxe

--- a/config-203.cvs
+++ b/config-203.cvs
@@ -1,8 +1,8 @@
 key,type,encoding,value
 main,namespace,,
 hostname,data,string,bitaxe
-wifissid,data,string,myssid
-wifipass,data,string,password
+wifissid,data,string,
+wifipass,data,string,
 stratumurl,data,string,public-pool.io
 stratumport,data,u16,21496
 stratumuser,data,string,bc1qnp980s5fpp8l94p5cvttmtdqy8rvrq74qly2yrfmzkdsntqzlc5qkc4rkq.bitaxe

--- a/config-204.cvs
+++ b/config-204.cvs
@@ -1,8 +1,8 @@
 key,type,encoding,value
 main,namespace,,
 hostname,data,string,bitaxe
-wifissid,data,string,myssid
-wifipass,data,string,password
+wifissid,data,string,
+wifipass,data,string,
 stratumurl,data,string,public-pool.io
 stratumport,data,u16,21496
 stratumuser,data,string,bc1qnp980s5fpp8l94p5cvttmtdqy8rvrq74qly2yrfmzkdsntqzlc5qkc4rkq.bitaxe

--- a/config-205.cvs
+++ b/config-205.cvs
@@ -1,8 +1,8 @@
 key,type,encoding,value
 main,namespace,,
 hostname,data,string,bitaxe
-wifissid,data,string,myssid
-wifipass,data,string,password
+wifissid,data,string,
+wifipass,data,string,
 stratumurl,data,string,public-pool.io
 stratumport,data,u16,21496
 stratumuser,data,string,bc1qnp980s5fpp8l94p5cvttmtdqy8rvrq74qly2yrfmzkdsntqzlc5qkc4rkq.bitaxe

--- a/config-401.cvs
+++ b/config-401.cvs
@@ -1,8 +1,8 @@
 key,type,encoding,value
 main,namespace,,
 hostname,data,string,bitaxe
-wifissid,data,string,myssid
-wifipass,data,string,password
+wifissid,data,string,
+wifipass,data,string,
 stratumurl,data,string,public-pool.io
 stratumport,data,u16,21496
 stratumuser,data,string,bc1qnp980s5fpp8l94p5cvttmtdqy8rvrq74qly2yrfmzkdsntqzlc5qkc4rkq.bitaxe

--- a/config-402.cvs
+++ b/config-402.cvs
@@ -1,8 +1,8 @@
 key,type,encoding,value
 main,namespace,,
 hostname,data,string,bitaxe
-wifissid,data,string,myssid
-wifipass,data,string,password
+wifissid,data,string,
+wifipass,data,string,
 stratumurl,data,string,public-pool.io
 stratumport,data,u16,21496
 stratumuser,data,string,bc1qnp980s5fpp8l94p5cvttmtdqy8rvrq74qly2yrfmzkdsntqzlc5qkc4rkq.bitaxe

--- a/config-403.cvs
+++ b/config-403.cvs
@@ -1,8 +1,8 @@
 key,type,encoding,value
 main,namespace,,
 hostname,data,string,bitaxe
-wifissid,data,string,myssid
-wifipass,data,string,password
+wifissid,data,string,
+wifipass,data,string,
 stratumurl,data,string,public-pool.io
 stratumport,data,u16,21496
 stratumuser,data,string,bc1qnp980s5fpp8l94p5cvttmtdqy8rvrq74qly2yrfmzkdsntqzlc5qkc4rkq.bitaxe

--- a/config-601.cvs
+++ b/config-601.cvs
@@ -1,8 +1,8 @@
 key,type,encoding,value
 main,namespace,,
 hostname,data,string,bitaxe
-wifissid,data,string,myssid
-wifipass,data,string,password
+wifissid,data,string,
+wifipass,data,string,
 stratumurl,data,string,public-pool.io
 stratumport,data,u16,21496
 stratumuser,data,string,bc1qnp980s5fpp8l94p5cvttmtdqy8rvrq74qly2yrfmzkdsntqzlc5qkc4rkq.bitaxe

--- a/main/main.c
+++ b/main/main.c
@@ -75,7 +75,7 @@ void app_main(void)
     strncpy(GLOBAL_STATE.SYSTEM_MODULE.ssid, wifi_ssid, sizeof(GLOBAL_STATE.SYSTEM_MODULE.ssid));
     GLOBAL_STATE.SYSTEM_MODULE.ssid[sizeof(GLOBAL_STATE.SYSTEM_MODULE.ssid)-1] = 0;
 
-    // init and connect to wifi
+    // init AP and connect to wifi
     wifi_init(wifi_ssid, wifi_pass, hostname, GLOBAL_STATE.SYSTEM_MODULE.ip_addr_str);
 
     generate_ssid(GLOBAL_STATE.SYSTEM_MODULE.ap_ssid);

--- a/main/screen.c
+++ b/main/screen.c
@@ -112,12 +112,13 @@ static lv_obj_t * create_scr_configure(SystemModule * module) {
     lv_obj_set_flex_align(scr, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
 
     lv_obj_t *label1 = lv_label_create(scr);
-    lv_obj_set_width(label1, LV_HOR_RES);
-    lv_label_set_long_mode(label1, LV_LABEL_LONG_SCROLL_CIRCULAR);
-    lv_label_set_text(label1, "Welcome to your new Bitaxe! Connect to the configuration Wifi and connect the Bitaxe to your network.");
+    lv_label_set_text(label1, "Hello BitAxe!");
+
+    // skip a line, it looks nicer this way
+    lv_label_create(scr);
 
     lv_obj_t *label2 = lv_label_create(scr);
-    lv_label_set_text(label2, "Wifi (join to setup):");
+    lv_label_set_text(label2, "Wi-Fi (for setup):");
 
     lv_obj_t *label3 = lv_label_create(scr);
     lv_label_set_text(label3, module->ap_ssid);
@@ -134,13 +135,13 @@ static lv_obj_t * create_scr_connection(SystemModule * module) {
     lv_obj_t *label1 = lv_label_create(scr);
     lv_obj_set_width(label1, LV_HOR_RES);    
     lv_label_set_long_mode(label1, LV_LABEL_LONG_SCROLL_CIRCULAR);
-    lv_label_set_text_fmt(label1, "Wifi: %s", module->ssid);
+    lv_label_set_text_fmt(label1, "Wi-Fi: %s", module->ssid);
 
     wifi_status_label = lv_label_create(scr);
     lv_label_set_text(wifi_status_label, module->wifi_status);
 
     lv_obj_t *label3 = lv_label_create(scr);
-    lv_label_set_text(label3, "Wifi (join to setup):");
+    lv_label_set_text(label3, "Wifi (for setup):");
 
     lv_obj_t *label4 = lv_label_create(scr);
     lv_label_set_text(label4, module->ap_ssid);

--- a/main/screen.c
+++ b/main/screen.c
@@ -97,7 +97,7 @@ static lv_obj_t * create_scr_invalid_asic(SystemModule * module) {
     lv_label_set_text(label1, "ASIC MODEL INVALID");
 
     lv_obj_t *label2 = lv_label_create(scr);
-    lv_label_set_text(label2, "Configuration SSID:");
+    lv_label_set_text(label2, "Wifi (join to setup):");
 
     lv_obj_t *label3 = lv_label_create(scr);
     lv_label_set_text(label3, module->ap_ssid);
@@ -117,7 +117,7 @@ static lv_obj_t * create_scr_configure(SystemModule * module) {
     lv_label_set_text(label1, "Welcome to your new Bitaxe! Connect to the configuration Wifi and connect the Bitaxe to your network.");
 
     lv_obj_t *label2 = lv_label_create(scr);
-    lv_label_set_text(label2, "Configuration SSID:");
+    lv_label_set_text(label2, "Wifi (join to setup):");
 
     lv_obj_t *label3 = lv_label_create(scr);
     lv_label_set_text(label3, module->ap_ssid);
@@ -134,13 +134,13 @@ static lv_obj_t * create_scr_connection(SystemModule * module) {
     lv_obj_t *label1 = lv_label_create(scr);
     lv_obj_set_width(label1, LV_HOR_RES);    
     lv_label_set_long_mode(label1, LV_LABEL_LONG_SCROLL_CIRCULAR);
-    lv_label_set_text_fmt(label1, "SSID: %s", module->ssid);
+    lv_label_set_text_fmt(label1, "Wifi: %s", module->ssid);
 
     wifi_status_label = lv_label_create(scr);
     lv_label_set_text(wifi_status_label, module->wifi_status);
 
     lv_obj_t *label3 = lv_label_create(scr);
-    lv_label_set_text(label3, "Configuration SSID:");
+    lv_label_set_text(label3, "Wifi (join to setup):");
 
     lv_obj_t *label4 = lv_label_create(scr);
     lv_label_set_text(label4, module->ap_ssid);

--- a/main/screen.c
+++ b/main/screen.c
@@ -112,7 +112,7 @@ static lv_obj_t * create_scr_configure(SystemModule * module) {
     lv_obj_set_flex_align(scr, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
 
     lv_obj_t *label1 = lv_label_create(scr);
-    lv_label_set_text(label1, "Hello BitAxe!");
+    lv_label_set_text(label1, "Hello Bitaxe!");
 
     // skip a line, it looks nicer this way
     lv_label_create(scr);


### PR DESCRIPTION
Use Wifi instead of SSID on screen, and add short `(join to setup)` message instead of `Configuration SSID`. This should be easier to understand, but does add 2 characters, which will fill the screen completely.

Fixes: #523