### PR TITLE
Init AxeOS AP mode

### DIFF
--- a/main/http_server/axe-os/src/app/app-routing.module.ts
+++ b/main/http_server/axe-os/src/app/app-routing.module.ts
@@ -13,8 +13,14 @@ import { ApModeGuard } from './guards/ap-mode.guard';
 
 const routes: Routes = [
   {
-    path: 'ap',
-    component: NetworkComponent
+      path: 'ap',
+      component: AppLayoutComponent,
+      children: [
+        {
+          path: '',
+          component: NetworkComponent
+        }
+      ]
   },
   {
     path: '',

--- a/main/http_server/axe-os/src/app/app-routing.module.ts
+++ b/main/http_server/axe-os/src/app/app-routing.module.ts
@@ -9,11 +9,17 @@ import { SwarmComponent } from './components/swarm/swarm.component';
 import { DesignComponent } from './components/design/design.component';
 import { PoolComponent } from './components/pool/pool.component';
 import { AppLayoutComponent } from './layout/app.layout.component';
+import { ApModeGuard } from './guards/ap-mode.guard';
 
 const routes: Routes = [
   {
+    path: 'ap',
+    component: NetworkComponent
+  },
+  {
     path: '',
     component: AppLayoutComponent,
+    canActivate: [ApModeGuard],
     children: [
       {
         path: '',

--- a/main/http_server/axe-os/src/app/guards/ap-mode.guard.ts
+++ b/main/http_server/axe-os/src/app/guards/ap-mode.guard.ts
@@ -1,0 +1,20 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { inject } from '@angular/core';
+import { Observable, map, catchError, of } from 'rxjs';
+import { SystemService } from '../services/system.service';
+
+export const ApModeGuard: CanActivateFn = (): Observable<boolean> => {
+  const systemService = inject(SystemService);
+  const router = inject(Router);
+
+  return systemService.getInfo().pipe(
+    map(info => {
+      if (info.apEnabled) {
+        router.navigate(['/ap']);
+        return false;
+      }
+      return true;
+    }),
+    catchError(() => of(true))
+  );
+}; 

--- a/main/http_server/axe-os/src/app/layout/app.layout.component.html
+++ b/main/http_server/axe-os/src/app/layout/app.layout.component.html
@@ -1,6 +1,6 @@
 <div class="layout-wrapper" [ngClass]="containerClass">
-    <app-topbar></app-topbar>
-    <div class="layout-sidebar">
+    <app-topbar [isAPMode]="isAPMode"></app-topbar>
+    <div class="layout-sidebar" *ngIf="!isAPMode">
         <app-sidebar></app-sidebar>
     </div>
     <div class="layout-main-container">

--- a/main/http_server/axe-os/src/app/layout/app.layout.component.ts
+++ b/main/http_server/axe-os/src/app/layout/app.layout.component.ts
@@ -109,6 +109,10 @@ export class AppLayoutComponent implements OnDestroy {
         }
     }
 
+    get isAPMode(): boolean {
+        return this.router.url.startsWith('/ap');
+    }
+
     ngOnDestroy() {
         if (this.overlayMenuOpenSubscription) {
             this.overlayMenuOpenSubscription.unsubscribe();

--- a/main/http_server/axe-os/src/app/layout/app.topbar.component.html
+++ b/main/http_server/axe-os/src/app/layout/app.topbar.component.html
@@ -3,7 +3,7 @@
         <div [routerLink]="['/']" class="header-text"><span style="font-family: Angel Wish; font-size: 4rem;">Axe</span><span class="os" style=" font-size: 3rem;">OS</span></div>
     </a>
 
-    <button #menubutton class="p-link layout-menu-button layout-topbar-button" (click)="layoutService.onMenuToggle()">
+    <button *ngIf="!isAPMode" #menubutton class="p-link layout-menu-button layout-topbar-button" (click)="layoutService.onMenuToggle()">
         <i class="pi pi-bars"></i>
     </button>
 

--- a/main/http_server/axe-os/src/app/layout/app.topbar.component.ts
+++ b/main/http_server/axe-os/src/app/layout/app.topbar.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, Input, ViewChild } from '@angular/core';
 import { MenuItem } from 'primeng/api';
 
 import { LayoutService } from './service/app.layout.service';
@@ -11,6 +11,8 @@ export class AppTopBarComponent {
 
     items!: MenuItem[];
 
+    @Input() isAPMode: boolean = false;
+    
     @ViewChild('menubutton') menuButton!: ElementRef;
 
     @ViewChild('topbarmenubutton') topbarMenuButton!: ElementRef;

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -37,6 +37,7 @@ export class SystemService {
           ssid: "default",
           wifiPass: "password",
           wifiStatus: "Connected!",
+          apEnabled: 0,
           sharesAccepted: 1,
           sharesRejected: 0,
           uptimeSeconds: 38,

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -37,7 +37,7 @@ export class SystemService {
           ssid: "default",
           wifiPass: "password",
           wifiStatus: "Connected!",
-          apEnabled: 1,
+          apEnabled: 0,
           sharesAccepted: 1,
           sharesRejected: 0,
           uptimeSeconds: 38,

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -37,7 +37,7 @@ export class SystemService {
           ssid: "default",
           wifiPass: "password",
           wifiStatus: "Connected!",
-          apEnabled: 0,
+          apEnabled: 1,
           sharesAccepted: 1,
           sharesRejected: 0,
           uptimeSeconds: 38,

--- a/main/http_server/axe-os/src/models/ISystemInfo.ts
+++ b/main/http_server/axe-os/src/models/ISystemInfo.ts
@@ -18,6 +18,7 @@ export interface ISystemInfo {
     macAddr: string,
     ssid: string,
     wifiStatus: string,
+    apEnabled: number,
     sharesAccepted: number,
     sharesRejected: number,
     uptimeSeconds: number,

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -551,6 +551,7 @@ static esp_err_t GET_system_info(httpd_req_t * req)
     cJSON_AddStringToObject(root, "macAddr", formattedMac);
     cJSON_AddStringToObject(root, "hostname", hostname);
     cJSON_AddStringToObject(root, "wifiStatus", GLOBAL_STATE->SYSTEM_MODULE.wifi_status);
+    cJSON_AddNumberToObject(root, "apEnabled", GLOBAL_STATE->SYSTEM_MODULE.ap_enabled);
     cJSON_AddNumberToObject(root, "sharesAccepted", GLOBAL_STATE->SYSTEM_MODULE.shares_accepted);
     cJSON_AddNumberToObject(root, "sharesRejected", GLOBAL_STATE->SYSTEM_MODULE.shares_rejected);
     cJSON_AddNumberToObject(root, "uptimeSeconds", (esp_timer_get_time() - GLOBAL_STATE->SYSTEM_MODULE.start_time) / 1000000);


### PR DESCRIPTION
Referring to these issues 

https://github.com/skot/ESP-Miner/issues/568
https://github.com/skot/ESP-Miner/issues/385

A way to do ap mode client side.  Only showing the network component when in ap mode

<img width="337" alt="image" src="https://github.com/user-attachments/assets/8cc82b92-e0f4-42be-92f8-01e157dab4d3" />

Thinking the AxeOS logo should be there and maybe some instructions like "Your Bitaxe is in Wi-fi setup mode. Enter your Wi-fi network name and password and restart for the full AxeOS experience".   A "Save & Restart" button might be nice too.
