### PR TITLE
add support for extranonce2_len<4

### DIFF
--- a/components/stratum/mining.c
+++ b/components/stratum/mining.c
@@ -115,7 +115,7 @@ char *extranonce_2_generate(uint32_t extranonce_2, uint32_t length)
     char *extranonce_2_str = malloc(length * 2 + 1);
     memset(extranonce_2_str, '0', length * 2);
     extranonce_2_str[length * 2] = '\0';
-    bin2hex((uint8_t *)&extranonce_2, sizeof(extranonce_2), extranonce_2_str, length * 2 + 1);
+    bin2hex((uint8_t *)&extranonce_2, length, extranonce_2_str, length * 2 + 1);
     if (length > 4)
     {
         extranonce_2_str[8] = '0';


### PR DESCRIPTION
fix https://github.com/skot/ESP-Miner/issues/658 

**Problem**


```
    char *extranonce_2_str = malloc(length * 2 + 1);
    memset(extranonce_2_str, '0', length * 2);
    extranonce_2_str[length * 2] = '\0';
    bin2hex((uint8_t *)&extranonce_2, sizeof(extranonce_2), extranonce_2_str, length * 2 + 1);
```

sizeof(extranonce_2) always returns 4
for the case of length = 3
```
char *extranonce_2_str = malloc(7);
malloc(7);
bin2hex((uint8_t *)&extranonce_2, 4, extranonce_2_str, 7);
```

in bin2hex we write based on that 4, so on i=3, we write hex[6]
```
for (size_t i = 0; i < 4; i++)
   hex2char(buf[i] >> 4, &hex[2 * i] <- we write here when we shouldn't
   hex2char(buf[i] & 0xf, &hex[2 * i + 1] 
```
what is hex[6]
well if we go back to the malloc its supposed to be the null terminator so we have a string that isnt null terminated :(

thats why length 3 has shares with more than 6 hex

**solution**
use length rather than static 4 for hex2bin func of extranonce2_generate
