### PR TITLE
Don't allow 0.0.0.0 in CORS

### DIFF
--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -83,18 +83,10 @@ static esp_err_t ip_in_private_range(uint32_t address) {
     return ESP_FAIL;
 }
 
-static uint32_t extract_origin_ip_addr(httpd_req_t *req)
+static uint32_t extract_origin_ip_addr(char *origin)
 {
-    char origin[128];
     char ip_str[16];
     uint32_t origin_ip_addr = 0;
-
-    // Attempt to get the Origin header.
-    if (httpd_req_get_hdr_value_str(req, "Origin", origin, sizeof(origin)) != ESP_OK) {
-        ESP_LOGD(CORS_TAG, "No origin header found.");
-        return 0;
-    }
-    ESP_LOGD(CORS_TAG, "Origin header: %s", origin);
 
     // Find the start of the IP address in the Origin header
     const char *prefix = "http://";
@@ -149,8 +141,14 @@ static esp_err_t is_network_allowed(httpd_req_t * req)
     // Convert to IPv4 string
     inet_ntop(AF_INET, &request_ip_addr, ipstr, sizeof(ipstr));
 
-    uint32_t origin_ip_addr = extract_origin_ip_addr(req);
-    if (origin_ip_addr == 0) {
+    // Attempt to get the Origin header.
+    char origin[128];
+    uint32_t origin_ip_addr;
+    if (httpd_req_get_hdr_value_str(req, "Origin", origin, sizeof(origin)) == ESP_OK) {
+        ESP_LOGD(CORS_TAG, "Origin header: %s", origin);
+        origin_ip_addr = extract_origin_ip_addr(origin);
+    } else {
+        ESP_LOGD(CORS_TAG, "No origin header found.");
         origin_ip_addr = request_ip_addr;
     }
 


### PR DESCRIPTION
This is mostly just weird behavior, as in theory we are allowing `0.0.0.0`, as we used `0` to detect a CORS failure making it fallback on the request ip address. This reorganizes the code a bit so that if CORS is set to `http://0.0.0.0` we evaluate it properly as `0`.