### PR TITLE
fix(ui): display placeholder for unavailable ASIC temp

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -146,7 +146,14 @@
                 <div class="grid">
                     <div class="col-12">
 
-                        <h6>ASIC Temperature <span style="float: right;">{{info.temp}}&deg;C</span></h6>
+                        <h6>ASIC Temperature 
+                            <span style="float: right;">
+                                <ng-template #noTemp>--</ng-template>
+                                <ng-container *ngIf="info.temp > 0; else noTemp">
+                                    {{info.temp}}&deg;C
+                                </ng-container>
+                            </span>
+                        </h6>
                         <p-progressBar [value]="(info.temp / maxTemp) * 100" [style]="{ height: '6px' }" >
                             <ng-template pTemplate="content" let-value></ng-template>
                         </p-progressBar>

--- a/main/screen.c
+++ b/main/screen.c
@@ -192,16 +192,16 @@ static lv_obj_t * create_scr_stats() {
     lv_obj_set_flex_align(scr, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
 
     hashrate_label = lv_label_create(scr);
-    lv_label_set_text(hashrate_label, "Gh/s: n/a");
+    lv_label_set_text(hashrate_label, "Gh/s: --");
 
     efficiency_label = lv_label_create(scr);
-    lv_label_set_text(efficiency_label, "J/Th: n/a");
+    lv_label_set_text(efficiency_label, "J/Th: --");
 
     difficulty_label = lv_label_create(scr);
-    lv_label_set_text(difficulty_label, "Best: n/a");
+    lv_label_set_text(difficulty_label, "Best: --");
 
     chip_temp_label = lv_label_create(scr);
-    lv_label_set_text(chip_temp_label, "Temp: n/a");
+    lv_label_set_text(chip_temp_label, "Temp: --");
 
     return scr;
 }


### PR DESCRIPTION
Instead of showing `-1` as the ASIC temperature value when it's not yet available, this change displays "--" as a placeholder. This aims to improve the user experience by avoiding a confusing negative temperature during initialization.

Resolves skot/ESP-Miner#680

Before:
![before](https://github.com/user-attachments/assets/a47e0aa3-bf6b-4b45-9cf6-1b9d284bd424)

After:
![after](https://github.com/user-attachments/assets/223f2f76-0116-48e8-a3fa-03871ccd6e7d)