### PR TITLE
Handle Voltage Regulator Faults

### DIFF
--- a/main/TPS546.c
+++ b/main/TPS546.c
@@ -393,43 +393,43 @@ int TPS546_init(void)
         TPS546_parse_status(status);
     }
 
-    // ESP_LOGI(TAG, "-----------VOLTAGE/CURRENT---------------------");
-    // /* Get voltage input (SLINEAR11) */
-    // ESP_LOGI(TAG, "READ_VIN: %.2fV", TPS546_get_vin());
-    // /* Get output current (SLINEAR11) */
-    // ESP_LOGI(TAG, "READ_IOUT: %.2fA", TPS546_get_iout());
-    // /* Get voltage output (ULINEAR16) */
-    // ESP_LOGI(TAG, "READ_VOUT: %.2fV", TPS546_get_vout());
+    ESP_LOGI(TAG, "-----------VOLTAGE/CURRENT---------------------");
+    smb_read_word(PMBUS_READ_VIN, &u16_value);
+    ESP_LOGI(TAG, "read READ_VIN: %.2fV", slinear11_2_float(u16_value));
+    smb_read_word(PMBUS_READ_IOUT, &u16_value);
+    ESP_LOGI(TAG, "read READ_IOUT: %.2fA", slinear11_2_float(u16_value));
+    smb_read_word(PMBUS_READ_VOUT, &u16_value);
+    ESP_LOGI(TAG, "read READ_VOUT: %.2fV", ulinear16_2_float(u16_value));
 
     ESP_LOGI(TAG, "-----------TIMING---------------------");
     smb_read_word(PMBUS_TON_DELAY, &u16_value);
     temp = slinear11_2_int(u16_value);
-    ESP_LOGI(TAG, "TON_DELAY: %d", temp);
+    ESP_LOGI(TAG, "read TON_DELAY: %dms", temp);
     smb_read_word(PMBUS_TON_RISE, &u16_value);
     temp = slinear11_2_int(u16_value);
-    ESP_LOGI(TAG, "TON_RISE: %d", temp);
+    ESP_LOGI(TAG, "read TON_RISE: %dms", temp);
     smb_read_word(PMBUS_TON_MAX_FAULT_LIMIT, &u16_value);
     temp = slinear11_2_int(u16_value);
-    ESP_LOGI(TAG, "TON_MAX_FAULT_LIMIT: %d", temp);
+    ESP_LOGI(TAG, "read TON_MAX_FAULT_LIMIT: %dms", temp);
     smb_read_byte(PMBUS_TON_MAX_FAULT_RESPONSE, &u8_value);
-    ESP_LOGI(TAG, "TON_MAX_FAULT_RESPONSE: %02x", u8_value);
+    ESP_LOGI(TAG, "read TON_MAX_FAULT_RESPONSE: %02x", u8_value);
     smb_read_word(PMBUS_TOFF_DELAY, &u16_value);
     temp = slinear11_2_int(u16_value);
-    ESP_LOGI(TAG, "TOFF_DELAY: %d", temp);
+    ESP_LOGI(TAG, "read TOFF_DELAY: %dms", temp);
     smb_read_word(PMBUS_TOFF_FALL, &u16_value);
     temp = slinear11_2_int(u16_value);
-    ESP_LOGI(TAG, "TOFF_FALL: %d", temp);
-    ESP_LOGI(TAG, "--------------------------------------");
+    ESP_LOGI(TAG, "read TOFF_FALL: %dms", temp);
+    ESP_LOGI(TAG, "---------CONFIG--------------------");
     smb_read_byte(PMBUS_PHASE, &u8_value);
-    ESP_LOGI(TAG, "PHASE: %02x", u8_value);
+    ESP_LOGI(TAG, "read PHASE: %02x", u8_value);
     smb_read_word(PMBUS_STACK_CONFIG, &u16_value);
-    ESP_LOGI(TAG, "STACK_CONFIG: %04x", u16_value);
+    ESP_LOGI(TAG, "read STACK_CONFIG: %04x", u16_value);
     smb_read_byte(PMBUS_SYNC_CONFIG, &u8_value);
-    ESP_LOGI(TAG, "SYNC_CONFIG: %02x", u8_value);
+    ESP_LOGI(TAG, "read SYNC_CONFIG: %02x", u8_value);
     smb_read_word(PMBUS_INTERLEAVE, &u16_value);
-    ESP_LOGI(TAG, "INTERLEAVE: %04x", u16_value);
+    ESP_LOGI(TAG, "read INTERLEAVE: %04x", u16_value);
     smb_read_byte(PMBUS_CAPABILITY, &u8_value);
-    ESP_LOGI(TAG, "CAPABILITY: %02x", u8_value);
+    ESP_LOGI(TAG, "read CAPABILITY: %02x", u8_value);
 
 
     // Read the compensation config registers
@@ -437,7 +437,7 @@ int TPS546_init(void)
         ESP_LOGE(TAG, "Failed to read COMPENSATION CONFIG");
         return -1;
     }
-    ESP_LOGI(TAG, "COMPENSATION CONFIG");
+    ESP_LOGI(TAG, "read COMPENSATION CONFIG");
     ESP_LOGI(TAG, "%02x %02x %02x %02x %02x", comp_config[0], comp_config[1],
         comp_config[2], comp_config[3], comp_config[4]);
 
@@ -522,6 +522,9 @@ void TPS546_write_entire_config(void)
     smb_write_word(PMBUS_FREQUENCY_SWITCH, int_2_slinear11(TPS546_INIT_FREQUENCY));
 
     /* vin voltage */
+    ESP_LOGI(TAG, "Setting VIN_UV_WARN_LIMIT: %.2f", TPS546_INIT_VIN_UV_WARN_LIMIT);
+    smb_write_word(PMBUS_VIN_UV_WARN_LIMIT, float_2_slinear11(TPS546_INIT_VIN_UV_WARN_LIMIT));
+
     ESP_LOGI(TAG, "Setting VIN_ON: %.2f", TPS546_INIT_VIN_ON);
     smb_write_word(PMBUS_VIN_ON, float_2_slinear11(TPS546_INIT_VIN_ON));
 
@@ -530,9 +533,6 @@ void TPS546_write_entire_config(void)
 
     ESP_LOGI(TAG, "Setting VIN_OV_FAULT_LIMIT: %.2f", TPS546_INIT_VIN_OV_FAULT_LIMIT);
     smb_write_word(PMBUS_VIN_OV_FAULT_LIMIT, float_2_slinear11(TPS546_INIT_VIN_OV_FAULT_LIMIT));
-
-    ESP_LOGI(TAG, "Setting VIN_UV_WARN_LIMIT: %.2f", TPS546_INIT_VIN_UV_WARN_LIMIT);
-    smb_write_word(PMBUS_VIN_UV_WARN_LIMIT, float_2_slinear11(TPS546_INIT_VIN_UV_WARN_LIMIT));
 
     ESP_LOGI(TAG, "Setting VIN_OV_FAULT_RESPONSE: %02X", TPS546_INIT_VIN_OV_FAULT_RESPONSE);
     smb_write_byte(PMBUS_VIN_OV_FAULT_RESPONSE, TPS546_INIT_VIN_OV_FAULT_RESPONSE);
@@ -569,33 +569,38 @@ void TPS546_write_entire_config(void)
     smb_write_word(PMBUS_VOUT_MIN, float_2_ulinear16(TPS546_INIT_VOUT_MIN));
 
     /* iout current */
-    ESP_LOGI(TAG, "Setting IOUT");
+    ESP_LOGI(TAG, "----- IOUT");
+    ESP_LOGI(TAG, "Setting IOUT_OC_WARN_LIMIT: %.2fA", TPS546_INIT_IOUT_OC_WARN_LIMIT);
     smb_write_word(PMBUS_IOUT_OC_WARN_LIMIT, float_2_slinear11(TPS546_INIT_IOUT_OC_WARN_LIMIT));
+
+    ESP_LOGI(TAG, "Setting IOUT_OC_FAULT_LIMIT: %.2fA", TPS546_INIT_IOUT_OC_FAULT_LIMIT);
     smb_write_word(PMBUS_IOUT_OC_FAULT_LIMIT, float_2_slinear11(TPS546_INIT_IOUT_OC_FAULT_LIMIT));
+
+    ESP_LOGI(TAG, "Setting IOUT_OC_FAULT_RESPONSE: %02x", TPS546_INIT_IOUT_OC_FAULT_RESPONSE);
     smb_write_byte(PMBUS_IOUT_OC_FAULT_RESPONSE, TPS546_INIT_IOUT_OC_FAULT_RESPONSE);
 
     /* temperature */
-    ESP_LOGI(TAG, "Setting TEMPERATURE");
-    ESP_LOGI(TAG, "Setting OT_WARN_LIMIT: %d", TPS546_INIT_OT_WARN_LIMIT);
+    ESP_LOGI(TAG, "----- TEMPERATURE");
+    ESP_LOGI(TAG, "Setting OT_WARN_LIMIT: %dC", TPS546_INIT_OT_WARN_LIMIT);
     smb_write_word(PMBUS_OT_WARN_LIMIT, int_2_slinear11(TPS546_INIT_OT_WARN_LIMIT));
-    ESP_LOGI(TAG, "Setting OT_FAULT_LIMIT: %d", TPS546_INIT_OT_FAULT_LIMIT);
+    ESP_LOGI(TAG, "Setting OT_FAULT_LIMIT: %dC", TPS546_INIT_OT_FAULT_LIMIT);
     smb_write_word(PMBUS_OT_FAULT_LIMIT, int_2_slinear11(TPS546_INIT_OT_FAULT_LIMIT));
     ESP_LOGI(TAG, "Setting OT_FAULT_RESPONSE: %02x", TPS546_INIT_OT_FAULT_RESPONSE);
     smb_write_byte(PMBUS_OT_FAULT_RESPONSE, TPS546_INIT_OT_FAULT_RESPONSE);
 
     /* timing */
-    ESP_LOGI(TAG, "Setting TIMING");
-    ESP_LOGI(TAG, "Setting TON_DELAY: %d", TPS546_INIT_TON_DELAY);
+    ESP_LOGI(TAG, "----- TIMING");
+    ESP_LOGI(TAG, "Setting TON_DELAY: %dms", TPS546_INIT_TON_DELAY);
     smb_write_word(PMBUS_TON_DELAY, int_2_slinear11(TPS546_INIT_TON_DELAY));
-    ESP_LOGI(TAG, "Setting TON_RISE: %d", TPS546_INIT_TON_RISE);
+    ESP_LOGI(TAG, "Setting TON_RISE: %dms", TPS546_INIT_TON_RISE);
     smb_write_word(PMBUS_TON_RISE, int_2_slinear11(TPS546_INIT_TON_RISE));
-    ESP_LOGI(TAG, "Setting TON_MAX_FAULT_LIMIT: %d", TPS546_INIT_TON_MAX_FAULT_LIMIT);
+    ESP_LOGI(TAG, "Setting TON_MAX_FAULT_LIMIT: %dms", TPS546_INIT_TON_MAX_FAULT_LIMIT);
     smb_write_word(PMBUS_TON_MAX_FAULT_LIMIT, int_2_slinear11(TPS546_INIT_TON_MAX_FAULT_LIMIT));
     ESP_LOGI(TAG, "Setting TON_MAX_FAULT_RESPONSE: %02x", TPS546_INIT_TON_MAX_FAULT_RESPONSE);
     smb_write_byte(PMBUS_TON_MAX_FAULT_RESPONSE, TPS546_INIT_TON_MAX_FAULT_RESPONSE);
-    ESP_LOGI(TAG, "Setting TOFF_DELAY: %d", TPS546_INIT_TOFF_DELAY);
+    ESP_LOGI(TAG, "Setting TOFF_DELAY: %dms", TPS546_INIT_TOFF_DELAY);
     smb_write_word(PMBUS_TOFF_DELAY, int_2_slinear11(TPS546_INIT_TOFF_DELAY));
-    ESP_LOGI(TAG, "Setting TOFF_FALL: %d", TPS546_INIT_TOFF_FALL);
+    ESP_LOGI(TAG, "Setting TOFF_FALL: %dms", TPS546_INIT_TOFF_FALL);
     smb_write_word(PMBUS_TOFF_FALL, int_2_slinear11(TPS546_INIT_TOFF_FALL));
 
     /* Compensation config */
@@ -722,8 +727,6 @@ esp_err_t TPS546_check_status(uint16_t *status) {
     if (smb_read_word(PMBUS_STATUS_WORD, status) != ESP_OK) {
         ESP_LOGE(TAG, "Could not read STATUS_WORD");
         return ESP_FAIL;
-    } else {
-        ESP_LOGI(TAG, "TPS546 Status: %04X", *status);
     }
     return ESP_OK;
 }
@@ -886,70 +889,70 @@ void TPS546_show_voltage_settings(void)
     /* VIN_ON SLINEAR11 */
     smb_read_word(PMBUS_VIN_ON, &u16_value);
     f_value = slinear11_2_float(u16_value);
-    ESP_LOGI(TAG, "VIN ON set to: %.2f", f_value);
+    ESP_LOGI(TAG, "read VIN_ON: %.2f V", f_value);
 
     /* VIN_OFF SLINEAR11 */
     smb_read_word(PMBUS_VIN_OFF, &u16_value);
     f_value = slinear11_2_float(u16_value);
-    ESP_LOGI(TAG, "VIN OFF set to: %.2f", f_value);
+    ESP_LOGI(TAG, "read VIN_OFF: %.2f V", f_value);
 
     /* VIN_OV_FAULT_LIMIT SLINEAR11 */
     smb_read_word(PMBUS_VIN_OV_FAULT_LIMIT, &u16_value);
     f_value = slinear11_2_float(u16_value);
-    ESP_LOGI(TAG, "VIN_OV_FAULT_LIMIT set to: %.2f", f_value);
+    ESP_LOGI(TAG, "read VIN_OV_FAULT_LIMIT: %.2f V", f_value);
 
     /* VIN_UV_WARN_LIMIT SLINEAR11 */
     smb_read_word(PMBUS_VIN_UV_WARN_LIMIT, &u16_value);
     f_value = slinear11_2_float(u16_value);
-    ESP_LOGI(TAG, "VIN_UV_WARN_LIMIT set to: %.2f", f_value);
+    ESP_LOGI(TAG, "read VIN_UV_WARN_LIMIT: %.2f V", f_value);
 
     /* VIN_OV_FAULT_RESPONSE */
     smb_read_byte(PMBUS_VIN_OV_FAULT_RESPONSE, &u8_value);
-    ESP_LOGI(TAG, "VIN_OV_FAULT_RESPONSE set to: %.2X", u8_value);
+    ESP_LOGI(TAG, "read VIN_OV_FAULT_RESPONSE: %.2X V", u8_value);
 
     /* VOUT_MAX */
     smb_read_word(PMBUS_VOUT_MAX, &u16_value);
     f_value = ulinear16_2_float(u16_value);
-    ESP_LOGI(TAG, "Vout Max set to: %.2f V", f_value);
+    ESP_LOGI(TAG, "read VOUT_MAX: %.2f V", f_value);
 
     /* VOUT_OV_FAULT_LIMIT */
     smb_read_word(PMBUS_VOUT_OV_FAULT_LIMIT, &u16_value);
     f_value = ulinear16_2_float(u16_value);
-    ESP_LOGI(TAG, "Vout OV Fault Limit: %.2f %%", f_value * 100.0);
+    ESP_LOGI(TAG, "read VOUT_OV_FAULT_LIMIT: %.2f V", f_value * TPS546_INIT_VOUT_COMMAND);
 
     /* VOUT_OV_WARN_LIMIT */
     smb_read_word(PMBUS_VOUT_OV_WARN_LIMIT, &u16_value);
     f_value = ulinear16_2_float(u16_value);
-    ESP_LOGI(TAG, "Vout OV Warn Limit: %.2f %%", f_value * 100.0);
+    ESP_LOGI(TAG, "read VOUT_OV_WARN_LIMIT: %.2f V", f_value * TPS546_INIT_VOUT_COMMAND);
 
     /* VOUT_MARGIN_HIGH */
     smb_read_word(PMBUS_VOUT_MARGIN_HIGH, &u16_value);
     f_value = ulinear16_2_float(u16_value);
-    ESP_LOGI(TAG, "Vout Margin HIGH: %.2f %%", f_value * 100.0);
+    ESP_LOGI(TAG, "read VOUT_MARGIN_HIGH: %.2f V", f_value * TPS546_INIT_VOUT_COMMAND);
 
     /* --- VOUT_COMMAND --- */
     smb_read_word(PMBUS_VOUT_COMMAND, &u16_value);
     f_value = ulinear16_2_float(u16_value);
-    ESP_LOGI(TAG, "Vout set to: %.2f V", f_value);
+    ESP_LOGI(TAG, "read VOUT_COMMAND: %.2f V", f_value);
 
     /* VOUT_MARGIN_LOW */
     smb_read_word(PMBUS_VOUT_MARGIN_LOW, &u16_value);
     f_value = ulinear16_2_float(u16_value);
-    ESP_LOGI(TAG, "Vout Margin LOW: %.2f %%", f_value * 100.0);
+    ESP_LOGI(TAG, "read VOUT_MARGIN_LOW: %.2f V", f_value * TPS546_INIT_VOUT_COMMAND);
 
     /* VOUT_UV_WARN_LIMIT */
     smb_read_word(PMBUS_VOUT_UV_WARN_LIMIT, &u16_value);
     f_value = ulinear16_2_float(u16_value);
-    ESP_LOGI(TAG, "Vout UV Warn Limit: %.2f %%", f_value * 100.0);
+    ESP_LOGI(TAG, "read VOUT_UV_WARN_LIMIT: %.2f V", f_value * TPS546_INIT_VOUT_COMMAND);
 
     /* VOUT_UV_FAULT_LIMIT */
     smb_read_word(PMBUS_VOUT_UV_FAULT_LIMIT, &u16_value);
     f_value = ulinear16_2_float(u16_value);
-    ESP_LOGI(TAG, "Vout UV Fault Limit: %.2f %%", f_value * 100.0);
+    ESP_LOGI(TAG, "read VOUT_UV_FAULT_LIMIT: %.2f V", f_value * TPS546_INIT_VOUT_COMMAND);
 
     /* VOUT_MIN */
     smb_read_word(PMBUS_VOUT_MIN, &u16_value);
     f_value = ulinear16_2_float(u16_value);
-    ESP_LOGI(TAG, "Vout Min set to: %.2f V", f_value);
+    ESP_LOGI(TAG, "read VOUT_MIN: %.2f V", f_value);
 }
 

--- a/main/TPS546.c
+++ b/main/TPS546.c
@@ -57,6 +57,15 @@ static esp_err_t smb_write_byte(uint8_t command, uint8_t data)
 }
 
 /**
+ * @brief SMBus write addr
+ * @param command The command to write
+ */
+static esp_err_t smb_write_addr(uint8_t command)
+{
+    return i2c_bitaxe_register_write_addr(tps546_dev_handle, command);
+}
+
+/**
  * @brief SMBus read word
  * @param command The command to read
  * @param result Pointer to store the read data
@@ -355,8 +364,6 @@ int TPS546_init(void)
     /* Read version number and see if it matches */
     TPS546_read_mfr_info(read_mfr_revision);
     // if (memcmp(read_mfr_revision, MFR_REVISION, 3) != 0) {
-
-    TPS546_clear_faults();
     
     // If it doesn't match, then write all the registers and set new version number
     // ESP_LOGI(TAG, "--------------------------------");
@@ -423,11 +430,16 @@ int TPS546_init(void)
     ESP_LOGI(TAG, "%02x %02x %02x %02x %02x", comp_config[0], comp_config[1],
         comp_config[2], comp_config[3], comp_config[4]);
 
+
+    ESP_LOGI(TAG, "Clearing faults");
+    TPS546_clear_faults();
+
     return 0;
 }
 
 esp_err_t TPS546_clear_faults(void) {
-    if (smb_write_byte(PMBUS_CLEAR_FAULTS, 0xFF) != ESP_OK) {
+    // if (smb_write_byte(PMBUS_CLEAR_FAULTS, 0xFF) != ESP_OK) {
+    if (smb_write_addr(PMBUS_CLEAR_FAULTS) != ESP_OK) {
         ESP_LOGE(TAG, "Failed to clear faults");
         return ESP_FAIL;
     }

--- a/main/TPS546.c
+++ b/main/TPS546.c
@@ -426,6 +426,10 @@ int TPS546_init(void)
     ESP_LOGI(TAG, "STACK_CONFIG: %04x", u16_value);
     smb_read_byte(PMBUS_SYNC_CONFIG, &u8_value);
     ESP_LOGI(TAG, "SYNC_CONFIG: %02x", u8_value);
+    smb_read_word(PMBUS_INTERLEAVE, &u16_value);
+    ESP_LOGI(TAG, "INTERLEAVE: %04x", u16_value);
+    smb_read_byte(PMBUS_CAPABILITY, &u8_value);
+    ESP_LOGI(TAG, "CAPABILITY: %02x", u8_value);
 
 
     // Read the compensation config registers
@@ -520,6 +524,7 @@ void TPS546_write_entire_config(void)
     /* vin voltage */
     ESP_LOGI(TAG, "Setting VIN_ON: %.2f", TPS546_INIT_VIN_ON);
     smb_write_word(PMBUS_VIN_ON, float_2_slinear11(TPS546_INIT_VIN_ON));
+
     ESP_LOGI(TAG, "Setting VIN_OFF: %.2f", TPS546_INIT_VIN_OFF);
     smb_write_word(PMBUS_VIN_OFF, float_2_slinear11(TPS546_INIT_VIN_OFF));
 
@@ -535,23 +540,32 @@ void TPS546_write_entire_config(void)
     /* vout voltage */
     ESP_LOGI(TAG, "Setting VOUT SCALE: %.2f", TPS546_INIT_SCALE_LOOP);
     smb_write_word(PMBUS_VOUT_SCALE_LOOP, float_2_slinear11(TPS546_INIT_SCALE_LOOP));
-    ESP_LOGI(TAG, "VOUT_COMMAND: %.2f", TPS546_INIT_VOUT_COMMAND);
+
+    ESP_LOGI(TAG, "Setting VOUT_COMMAND: %.2f", TPS546_INIT_VOUT_COMMAND);
     smb_write_word(PMBUS_VOUT_COMMAND, float_2_ulinear16(TPS546_INIT_VOUT_COMMAND));
-    ESP_LOGI(TAG, "VOUT_MAX: %d", TPS546_INIT_VOUT_MAX);
+
+    ESP_LOGI(TAG, "Setting VOUT_MAX: %d", TPS546_INIT_VOUT_MAX);
     smb_write_word(PMBUS_VOUT_MAX, float_2_ulinear16(TPS546_INIT_VOUT_MAX));
-    ESP_LOGI(TAG, "VOUT_OV_FAULT_LIMIT: %.2f", TPS546_INIT_VOUT_OV_FAULT_LIMIT);
+
+    ESP_LOGI(TAG, "Setting VOUT_OV_FAULT_LIMIT: %.2f", TPS546_INIT_VOUT_OV_FAULT_LIMIT);
     smb_write_word(PMBUS_VOUT_OV_FAULT_LIMIT, float_2_ulinear16(TPS546_INIT_VOUT_OV_FAULT_LIMIT));
-    ESP_LOGI(TAG, "VOUT_OV_WARN_LIMIT: %.2f", TPS546_INIT_VOUT_OV_WARN_LIMIT);
+
+    ESP_LOGI(TAG, "Setting VOUT_OV_WARN_LIMIT: %.2f", TPS546_INIT_VOUT_OV_WARN_LIMIT);
     smb_write_word(PMBUS_VOUT_OV_WARN_LIMIT, float_2_ulinear16(TPS546_INIT_VOUT_OV_WARN_LIMIT));
-    ESP_LOGI(TAG, "VOUT_MARGIN_HIGH: %.2f", TPS546_INIT_VOUT_MARGIN_HIGH);
+
+    ESP_LOGI(TAG, "Setting VOUT_MARGIN_HIGH: %.2f", TPS546_INIT_VOUT_MARGIN_HIGH);
     smb_write_word(PMBUS_VOUT_MARGIN_HIGH, float_2_ulinear16(TPS546_INIT_VOUT_MARGIN_HIGH));
-    ESP_LOGI(TAG, "VOUT_MARGIN_LOW: %.2f", TPS546_INIT_VOUT_MARGIN_LOW);
+
+    ESP_LOGI(TAG, "Setting VOUT_MARGIN_LOW: %.2f", TPS546_INIT_VOUT_MARGIN_LOW);
     smb_write_word(PMBUS_VOUT_MARGIN_LOW, float_2_ulinear16(TPS546_INIT_VOUT_MARGIN_LOW));
-    ESP_LOGI(TAG, "VOUT_UV_WARN_LIMIT: %.2f", TPS546_INIT_VOUT_UV_WARN_LIMIT);
+
+    ESP_LOGI(TAG, "Setting VOUT_UV_WARN_LIMIT: %.2f", TPS546_INIT_VOUT_UV_WARN_LIMIT);
     smb_write_word(PMBUS_VOUT_UV_WARN_LIMIT, float_2_ulinear16(TPS546_INIT_VOUT_UV_WARN_LIMIT));
-    ESP_LOGI(TAG, "VOUT_UV_FAULT_LIMIT: %.2f", TPS546_INIT_VOUT_UV_FAULT_LIMIT);
+
+    ESP_LOGI(TAG, "Setting VOUT_UV_FAULT_LIMIT: %.2f", TPS546_INIT_VOUT_UV_FAULT_LIMIT);
     smb_write_word(PMBUS_VOUT_UV_FAULT_LIMIT, float_2_ulinear16(TPS546_INIT_VOUT_UV_FAULT_LIMIT));
-    ESP_LOGI(TAG, "VOUT_MIN: %d", TPS546_INIT_VOUT_MIN);
+
+    ESP_LOGI(TAG, "Setting VOUT_MIN: %d", TPS546_INIT_VOUT_MIN);
     smb_write_word(PMBUS_VOUT_MIN, float_2_ulinear16(TPS546_INIT_VOUT_MIN));
 
     /* iout current */
@@ -562,26 +576,26 @@ void TPS546_write_entire_config(void)
 
     /* temperature */
     ESP_LOGI(TAG, "Setting TEMPERATURE");
-    ESP_LOGI(TAG, "OT_WARN_LIMIT: %d", TPS546_INIT_OT_WARN_LIMIT);
+    ESP_LOGI(TAG, "Setting OT_WARN_LIMIT: %d", TPS546_INIT_OT_WARN_LIMIT);
     smb_write_word(PMBUS_OT_WARN_LIMIT, int_2_slinear11(TPS546_INIT_OT_WARN_LIMIT));
-    ESP_LOGI(TAG, "OT_FAULT_LIMIT: %d", TPS546_INIT_OT_FAULT_LIMIT);
+    ESP_LOGI(TAG, "Setting OT_FAULT_LIMIT: %d", TPS546_INIT_OT_FAULT_LIMIT);
     smb_write_word(PMBUS_OT_FAULT_LIMIT, int_2_slinear11(TPS546_INIT_OT_FAULT_LIMIT));
-    ESP_LOGI(TAG, "OT_FAULT_RESPONSE: %02x", TPS546_INIT_OT_FAULT_RESPONSE);
+    ESP_LOGI(TAG, "Setting OT_FAULT_RESPONSE: %02x", TPS546_INIT_OT_FAULT_RESPONSE);
     smb_write_byte(PMBUS_OT_FAULT_RESPONSE, TPS546_INIT_OT_FAULT_RESPONSE);
 
     /* timing */
     ESP_LOGI(TAG, "Setting TIMING");
-    ESP_LOGI(TAG, "TON_DELAY: %d", TPS546_INIT_TON_DELAY);
+    ESP_LOGI(TAG, "Setting TON_DELAY: %d", TPS546_INIT_TON_DELAY);
     smb_write_word(PMBUS_TON_DELAY, int_2_slinear11(TPS546_INIT_TON_DELAY));
-    ESP_LOGI(TAG, "TON_RISE: %d", TPS546_INIT_TON_RISE);
+    ESP_LOGI(TAG, "Setting TON_RISE: %d", TPS546_INIT_TON_RISE);
     smb_write_word(PMBUS_TON_RISE, int_2_slinear11(TPS546_INIT_TON_RISE));
-    ESP_LOGI(TAG, "TON_MAX_FAULT_LIMIT: %d", TPS546_INIT_TON_MAX_FAULT_LIMIT);
+    ESP_LOGI(TAG, "Setting TON_MAX_FAULT_LIMIT: %d", TPS546_INIT_TON_MAX_FAULT_LIMIT);
     smb_write_word(PMBUS_TON_MAX_FAULT_LIMIT, int_2_slinear11(TPS546_INIT_TON_MAX_FAULT_LIMIT));
-    ESP_LOGI(TAG, "TON_MAX_FAULT_RESPONSE: %02x", TPS546_INIT_TON_MAX_FAULT_RESPONSE);
+    ESP_LOGI(TAG, "Setting TON_MAX_FAULT_RESPONSE: %02x", TPS546_INIT_TON_MAX_FAULT_RESPONSE);
     smb_write_byte(PMBUS_TON_MAX_FAULT_RESPONSE, TPS546_INIT_TON_MAX_FAULT_RESPONSE);
-    ESP_LOGI(TAG, "TOFF_DELAY: %d", TPS546_INIT_TOFF_DELAY);
+    ESP_LOGI(TAG, "Setting TOFF_DELAY: %d", TPS546_INIT_TOFF_DELAY);
     smb_write_word(PMBUS_TOFF_DELAY, int_2_slinear11(TPS546_INIT_TOFF_DELAY));
-    ESP_LOGI(TAG, "TOFF_FALL: %d", TPS546_INIT_TOFF_FALL);
+    ESP_LOGI(TAG, "Setting TOFF_FALL: %d", TPS546_INIT_TOFF_FALL);
     smb_write_word(PMBUS_TOFF_FALL, int_2_slinear11(TPS546_INIT_TOFF_FALL));
 
     /* Compensation config */
@@ -593,11 +607,11 @@ void TPS546_write_entire_config(void)
     smb_write_word(PMBUS_PIN_DETECT_OVERRIDE, INIT_PIN_DETECT_OVERRIDE);
 
     /* TODO write new MFR_REVISION number to reflect these parameters */
-    ESP_LOGI(TAG, "Writing MFR ID");
+    ESP_LOGI(TAG, "Setting MFR ID");
     smb_write_block(PMBUS_MFR_ID, MFR_ID, 3);
-    ESP_LOGI(TAG, "Writing MFR MODEL");
+    ESP_LOGI(TAG, "Setting MFR MODEL");
     smb_write_block(PMBUS_MFR_ID, MFR_MODEL, 3);
-    ESP_LOGI(TAG, "Writing MFR REVISION");
+    ESP_LOGI(TAG, "Setting MFR REVISION");
     smb_write_block(PMBUS_MFR_ID, MFR_REVISION, 3);
 
     /*
@@ -865,6 +879,7 @@ void TPS546_set_vout(float volts)
 void TPS546_show_voltage_settings(void)
 {
     uint16_t u16_value;
+    uint8_t u8_value;
     float f_value;
 
     ESP_LOGI(TAG, "-----------VOLTAGE---------------------");
@@ -878,6 +893,20 @@ void TPS546_show_voltage_settings(void)
     f_value = slinear11_2_float(u16_value);
     ESP_LOGI(TAG, "VIN OFF set to: %.2f", f_value);
 
+    /* VIN_OV_FAULT_LIMIT SLINEAR11 */
+    smb_read_word(PMBUS_VIN_OV_FAULT_LIMIT, &u16_value);
+    f_value = slinear11_2_float(u16_value);
+    ESP_LOGI(TAG, "VIN_OV_FAULT_LIMIT set to: %.2f", f_value);
+
+    /* VIN_UV_WARN_LIMIT SLINEAR11 */
+    smb_read_word(PMBUS_VIN_UV_WARN_LIMIT, &u16_value);
+    f_value = slinear11_2_float(u16_value);
+    ESP_LOGI(TAG, "VIN_UV_WARN_LIMIT set to: %.2f", f_value);
+
+    /* VIN_OV_FAULT_RESPONSE */
+    smb_read_byte(PMBUS_VIN_OV_FAULT_RESPONSE, &u8_value);
+    ESP_LOGI(TAG, "VIN_OV_FAULT_RESPONSE set to: %.2X", u8_value);
+
     /* VOUT_MAX */
     smb_read_word(PMBUS_VOUT_MAX, &u16_value);
     f_value = ulinear16_2_float(u16_value);
@@ -886,17 +915,17 @@ void TPS546_show_voltage_settings(void)
     /* VOUT_OV_FAULT_LIMIT */
     smb_read_word(PMBUS_VOUT_OV_FAULT_LIMIT, &u16_value);
     f_value = ulinear16_2_float(u16_value);
-    ESP_LOGI(TAG, "Vout OV Fault Limit: %.2f V", f_value);
+    ESP_LOGI(TAG, "Vout OV Fault Limit: %.2f %%", f_value * 100.0);
 
     /* VOUT_OV_WARN_LIMIT */
     smb_read_word(PMBUS_VOUT_OV_WARN_LIMIT, &u16_value);
     f_value = ulinear16_2_float(u16_value);
-    ESP_LOGI(TAG, "Vout OV Warn Limit: %.2f V", f_value);
+    ESP_LOGI(TAG, "Vout OV Warn Limit: %.2f %%", f_value * 100.0);
 
     /* VOUT_MARGIN_HIGH */
     smb_read_word(PMBUS_VOUT_MARGIN_HIGH, &u16_value);
     f_value = ulinear16_2_float(u16_value);
-    ESP_LOGI(TAG, "Vout Margin HIGH: %.2f V", f_value);
+    ESP_LOGI(TAG, "Vout Margin HIGH: %.2f %%", f_value * 100.0);
 
     /* --- VOUT_COMMAND --- */
     smb_read_word(PMBUS_VOUT_COMMAND, &u16_value);
@@ -906,17 +935,17 @@ void TPS546_show_voltage_settings(void)
     /* VOUT_MARGIN_LOW */
     smb_read_word(PMBUS_VOUT_MARGIN_LOW, &u16_value);
     f_value = ulinear16_2_float(u16_value);
-    ESP_LOGI(TAG, "Vout Margin LOW: %.2f V", f_value);
+    ESP_LOGI(TAG, "Vout Margin LOW: %.2f %%", f_value * 100.0);
 
     /* VOUT_UV_WARN_LIMIT */
     smb_read_word(PMBUS_VOUT_UV_WARN_LIMIT, &u16_value);
     f_value = ulinear16_2_float(u16_value);
-    ESP_LOGI(TAG, "Vout UV Warn Limit: %.2f V", f_value);
+    ESP_LOGI(TAG, "Vout UV Warn Limit: %.2f %%", f_value * 100.0);
 
     /* VOUT_UV_FAULT_LIMIT */
     smb_read_word(PMBUS_VOUT_UV_FAULT_LIMIT, &u16_value);
     f_value = ulinear16_2_float(u16_value);
-    ESP_LOGI(TAG, "Vout UV Fault Limit: %.2f V", f_value);
+    ESP_LOGI(TAG, "Vout UV Fault Limit: %.2f %%", f_value * 100.0);
 
     /* VOUT_MIN */
     smb_read_word(PMBUS_VOUT_MIN, &u16_value);

--- a/main/TPS546.c
+++ b/main/TPS546.c
@@ -420,6 +420,13 @@ int TPS546_init(void)
     temp = slinear11_2_int(u16_value);
     ESP_LOGI(TAG, "TOFF_FALL: %d", temp);
     ESP_LOGI(TAG, "--------------------------------------");
+    smb_read_byte(PMBUS_PHASE, &u8_value);
+    ESP_LOGI(TAG, "PHASE: %02x", u8_value);
+    smb_read_word(PMBUS_STACK_CONFIG, &u16_value);
+    ESP_LOGI(TAG, "STACK_CONFIG: %04x", u16_value);
+    smb_read_byte(PMBUS_SYNC_CONFIG, &u8_value);
+    ESP_LOGI(TAG, "SYNC_CONFIG: %02x", u8_value);
+
 
     // Read the compensation config registers
     if (smb_read_block(PMBUS_COMPENSATION_CONFIG, comp_config, 5) != ESP_OK) {
@@ -502,6 +509,10 @@ void TPS546_write_entire_config(void)
         return;
     }
 
+    /* Phase */
+    ESP_LOGI(TAG, "Setting PHASE");
+    smb_write_byte(PMBUS_PHASE, TPS546_INIT_PHASE);
+
     /* Switch frequency */
     ESP_LOGI(TAG, "Setting FREQUENCY");
     smb_write_word(PMBUS_FREQUENCY_SWITCH, int_2_slinear11(TPS546_INIT_FREQUENCY));
@@ -511,10 +522,13 @@ void TPS546_write_entire_config(void)
     smb_write_word(PMBUS_VIN_ON, float_2_slinear11(TPS546_INIT_VIN_ON));
     ESP_LOGI(TAG, "Setting VIN_OFF: %.2f", TPS546_INIT_VIN_OFF);
     smb_write_word(PMBUS_VIN_OFF, float_2_slinear11(TPS546_INIT_VIN_OFF));
-    ESP_LOGI(TAG, "Setting VIN_UV_WARN_LIMIT: %.2f", TPS546_INIT_VIN_UV_WARN_LIMIT);
-    smb_write_word(PMBUS_VIN_UV_WARN_LIMIT, float_2_slinear11(TPS546_INIT_VIN_UV_WARN_LIMIT));
+
     ESP_LOGI(TAG, "Setting VIN_OV_FAULT_LIMIT: %.2f", TPS546_INIT_VIN_OV_FAULT_LIMIT);
     smb_write_word(PMBUS_VIN_OV_FAULT_LIMIT, float_2_slinear11(TPS546_INIT_VIN_OV_FAULT_LIMIT));
+
+    ESP_LOGI(TAG, "Setting VIN_UV_WARN_LIMIT: %.2f", TPS546_INIT_VIN_UV_WARN_LIMIT);
+    smb_write_word(PMBUS_VIN_UV_WARN_LIMIT, float_2_slinear11(TPS546_INIT_VIN_UV_WARN_LIMIT));
+
     ESP_LOGI(TAG, "Setting VIN_OV_FAULT_RESPONSE: %02X", TPS546_INIT_VIN_OV_FAULT_RESPONSE);
     smb_write_byte(PMBUS_VIN_OV_FAULT_RESPONSE, TPS546_INIT_VIN_OV_FAULT_RESPONSE);
 

--- a/main/TPS546.h
+++ b/main/TPS546.h
@@ -16,11 +16,13 @@
 
 #define TPS546_INIT_FREQUENCY 650  /* KHz */
 
+#define TPS546_INIT_PHASE 0x00  /* phase */
+
 /* vin voltage */
 #define TPS546_INIT_VIN_ON  4.8  /* V */
 #define TPS546_INIT_VIN_OFF 4.5  /* V */
-#define TPS546_INIT_VIN_UV_WARN_LIMIT 5.8 /* V */
-#define TPS546_INIT_VIN_OV_FAULT_LIMIT 6.0 /* V */
+#define TPS546_INIT_VIN_UV_WARN_LIMIT 4.5 /* V */
+#define TPS546_INIT_VIN_OV_FAULT_LIMIT 5.5 /* V */
 #define TPS546_INIT_VIN_OV_FAULT_RESPONSE 0xB7  /* retry 6 times */
 
   /* vout voltage */

--- a/main/TPS546.h
+++ b/main/TPS546.h
@@ -25,7 +25,7 @@
 #define TPS546_INIT_VIN_OV_FAULT_LIMIT 5.5 /* V */
 #define TPS546_INIT_VIN_OV_FAULT_RESPONSE 0xB7  /* retry 6 times */
 
-  /* vout voltage */
+/* vout voltage */
 #define TPS546_INIT_SCALE_LOOP 0.25  /* Voltage Scale factor */
 #define TPS546_INIT_VOUT_MAX 2 /* V */
 #define TPS546_INIT_VOUT_OV_FAULT_LIMIT 1.2 // The hardware supports values from 105% to 140% of VOUT_COMMAND in 2.5% steps. When output conversion is disabled, the hardware supports values from 110% to 140% of VOUT_COMMAND in 10% steps.
@@ -37,12 +37,12 @@
 #define TPS546_INIT_VOUT_UV_FAULT_LIMIT 0.75 /* %/100 below VOUT_COMMAND */
 #define TPS546_INIT_VOUT_MIN 1 /* v */
 
-  /* iout current */
+/* iout current */
 #define TPS546_INIT_IOUT_OC_WARN_LIMIT  25.00 /* A */
 #define TPS546_INIT_IOUT_OC_FAULT_LIMIT 30.00 /* A */
 #define TPS546_INIT_IOUT_OC_FAULT_RESPONSE 0xC0  /* shut down, no retries */
 
-  /* temperature */
+/* temperature */
 // It is better to set the temperature warn limit for TPS546 more higher than Ultra 
 #define TPS546_INIT_OT_WARN_LIMIT  105 /* degrees C */
 #define TPS546_INIT_OT_FAULT_LIMIT 145 /* degrees C */

--- a/main/TPS546.h
+++ b/main/TPS546.h
@@ -21,15 +21,15 @@
 /* vin voltage */
 #define TPS546_INIT_VIN_ON  4.8  /* V */
 #define TPS546_INIT_VIN_OFF 4.5  /* V */
-#define TPS546_INIT_VIN_UV_WARN_LIMIT 4.5 /* V */
+#define TPS546_INIT_VIN_UV_WARN_LIMIT 4.8 /* V */
 #define TPS546_INIT_VIN_OV_FAULT_LIMIT 5.5 /* V */
 #define TPS546_INIT_VIN_OV_FAULT_RESPONSE 0xB7  /* retry 6 times */
 
   /* vout voltage */
 #define TPS546_INIT_SCALE_LOOP 0.25  /* Voltage Scale factor */
-#define TPS546_INIT_VOUT_MAX 3 /* V */
-#define TPS546_INIT_VOUT_OV_FAULT_LIMIT 1.25 /* %/100 above VOUT_COMMAND */
-#define TPS546_INIT_VOUT_OV_WARN_LIMIT  1.1 /* %/100 above VOUT_COMMAND */
+#define TPS546_INIT_VOUT_MAX 2 /* V */
+#define TPS546_INIT_VOUT_OV_FAULT_LIMIT 1.2 // The hardware supports values from 105% to 140% of VOUT_COMMAND in 2.5% steps. When output conversion is disabled, the hardware supports values from 110% to 140% of VOUT_COMMAND in 10% steps.
+#define TPS546_INIT_VOUT_OV_WARN_LIMIT  1.16 // The hardware supports values from 103% to 116% VOUT_COMMAND in 1% steps.
 #define TPS546_INIT_VOUT_MARGIN_HIGH 1.1 /* %/100 above VOUT */
 #define TPS546_INIT_VOUT_COMMAND 1.2  /* V absolute value */
 #define TPS546_INIT_VOUT_MARGIN_LOW 0.90 /* %/100 below VOUT */

--- a/main/TPS546.h
+++ b/main/TPS546.h
@@ -67,6 +67,24 @@
 #define ON_OFF_CONFIG_POLARITY 0x00 // turn off POLARITY bit
 #define ON_OFF_CONFIG_DELAY 0x00 // turn off DELAY bit
 
+//// STATUS_WORD Offsets
+#define TPS546_STATUS_VOUT    0x8000 //bit 15
+#define TPS546_STATUS_IOUT    0x4000
+#define TPS546_STATUS_INPUT   0x2000
+#define TPS546_STATUS_MFR     0x1000
+#define TPS546_STATUS_PGOOD   0x0800
+#define TPS546_STATUS_OTHER   0x0200
+
+#define TPS546_STATUS_BUSY    0x0080
+#define TPS546_STATUS_OFF     0x0040
+#define TPS546_STATUS_VOUT_OV 0x0020
+#define TPS546_STATUS_IOUT_OC 0x0010
+#define TPS546_STATUS_VIN_UV  0x0008
+#define TPS546_STATUS_TEMP    0x0004
+#define TPS546_STATUS_CML     0x0002
+#define TPS546_STATUS_NONE    0x0001
+
+
 
 /* public functions */
 int TPS546_init(void);
@@ -81,6 +99,8 @@ float TPS546_get_iout(void);
 float TPS546_get_vout(void);
 void TPS546_set_vout(float volts);
 void TPS546_show_voltage_settings(void);
-void TPS546_print_status(void);
+esp_err_t TPS546_check_status(uint16_t *);
+esp_err_t TPS546_parse_status(uint16_t status);
+esp_err_t TPS546_clear_faults(void);
 
 #endif /* TPS546_H_ */

--- a/main/i2c_bitaxe.c
+++ b/main/i2c_bitaxe.c
@@ -115,6 +115,18 @@ esp_err_t i2c_bitaxe_register_read(i2c_master_dev_handle_t dev_handle, uint8_t r
 }
 
 /**
+ * @brief Just write a register address to the I2C device
+ * 
+ * @param dev_handle 
+ * @param reg_addr 
+ * @return esp_err_t 
+ */
+esp_err_t i2c_bitaxe_register_write_addr(i2c_master_dev_handle_t dev_handle, uint8_t reg_addr)
+{
+    return log_on_error(i2c_master_transmit(dev_handle, &reg_addr, 1, I2C_DEFAULT_TIMEOUT), dev_handle);
+}
+
+/**
  * @brief Write a byte to a I2C register
  * @param dev_handle The I2C device handle
  * @param reg_addr The register address to write to

--- a/main/i2c_bitaxe.c
+++ b/main/i2c_bitaxe.c
@@ -108,9 +108,6 @@ esp_err_t i2c_bitaxe_get_master_bus_handle(i2c_master_bus_handle_t * dev_handle)
  */
 esp_err_t i2c_bitaxe_register_read(i2c_master_dev_handle_t dev_handle, uint8_t reg_addr, uint8_t * read_buf, size_t len)
 {
-    // return i2c_master_write_read_device(I2C_MASTER_NUM, device_address, &reg_addr, 1, data, len, I2C_MASTER_TIMEOUT_MS / portTICK_PERIOD_MS);
-    //ESP_LOGI("I2C", "Reading %d bytes from register 0x%02X", len, reg_addr);
-
     return log_on_error(i2c_master_transmit_receive(dev_handle, &reg_addr, 1, read_buf, len, I2C_DEFAULT_TIMEOUT), dev_handle);
 }
 
@@ -136,8 +133,6 @@ esp_err_t i2c_bitaxe_register_write_byte(i2c_master_dev_handle_t dev_handle, uin
 {
     uint8_t write_buf[2] = {reg_addr, data};
 
-    //return i2c_master_write_to_device(I2C_MASTER_NUM, device_address, write_buf, sizeof(write_buf), I2C_MASTER_TIMEOUT_MS / portTICK_PERIOD_MS);
-
     return log_on_error(i2c_master_transmit(dev_handle, write_buf, 2, I2C_DEFAULT_TIMEOUT), dev_handle);
 }
 
@@ -161,8 +156,6 @@ esp_err_t i2c_bitaxe_register_write_bytes(i2c_master_dev_handle_t dev_handle, ui
 esp_err_t i2c_bitaxe_register_write_word(i2c_master_dev_handle_t dev_handle, uint8_t reg_addr, uint16_t data)
 {
     uint8_t write_buf[3] = {reg_addr, (uint8_t)(data & 0x00FF), (uint8_t)((data & 0xFF00) >> 8)};
-
-    //return i2c_master_write_to_device(I2C_MASTER_NUM, device_address, write_buf, sizeof(write_buf), I2C_MASTER_TIMEOUT_MS / portTICK_PERIOD_MS);
 
     return log_on_error(i2c_master_transmit(dev_handle, write_buf, 3, I2C_DEFAULT_TIMEOUT), dev_handle);
 }

--- a/main/i2c_bitaxe.h
+++ b/main/i2c_bitaxe.h
@@ -13,5 +13,6 @@ esp_err_t i2c_bitaxe_register_read(i2c_master_dev_handle_t dev_handle, uint8_t r
 esp_err_t i2c_bitaxe_register_write_byte(i2c_master_dev_handle_t dev_handle, uint8_t reg_addr, uint8_t data);
 esp_err_t i2c_bitaxe_register_write_bytes(i2c_master_dev_handle_t dev_handle, uint8_t * data, uint8_t len);
 esp_err_t i2c_bitaxe_register_write_word(i2c_master_dev_handle_t dev_handle, uint8_t reg_addr, uint16_t data);
+esp_err_t i2c_bitaxe_register_write_addr(i2c_master_dev_handle_t dev_handle, uint8_t reg_addr);
 
 #endif /* I2C_MASTER_H_ */

--- a/main/tasks/power_management_task.c
+++ b/main/tasks/power_management_task.c
@@ -123,6 +123,7 @@ void POWER_MANAGEMENT_task(void * pvParameters)
     vTaskDelay(500 / portTICK_PERIOD_MS);
     uint16_t last_core_voltage = 0.0;
     uint16_t last_asic_frequency = power_management->frequency_value;
+    uint16_t TPS546_status;
     
     while (1) {
 
@@ -147,6 +148,11 @@ void POWER_MANAGEMENT_task(void * pvParameters)
             
                 break;
             case DEVICE_GAMMA:
+                    TPS546_check_status(&TPS546_status);
+                    if (TPS546_status != 0) {
+                        ESP_LOGE(TAG, "TPS546 Status error: %04x", TPS546_status);
+                        TPS546_parse_status(TPS546_status);
+                    }
                     power_management->voltage = TPS546_get_vin() * 1000;
                     power_management->current = TPS546_get_iout() * 1000;
                     // calculate regulator power (in milliwatts)

--- a/main/tasks/power_management_task.c
+++ b/main/tasks/power_management_task.c
@@ -152,6 +152,7 @@ void POWER_MANAGEMENT_task(void * pvParameters)
                     if (TPS546_status != 0) {
                         ESP_LOGE(TAG, "TPS546 Status error: %04x", TPS546_status);
                         TPS546_parse_status(TPS546_status);
+                        TPS546_clear_faults();
                     }
                     power_management->voltage = TPS546_get_vin() * 1000;
                     power_management->current = TPS546_get_iout() * 1000;


### PR DESCRIPTION
The TPS546D24A Voltage regulator has several status checks, such as;

- Output Voltage Over Current (OC)
- Output Voltage Over Voltage (OV)
- Output Voltage Under Voltage (UV)
- Regulator Over Temperature (OT)
- and more

These can all be configured on the TPS546 to do different things to handle faults. In some of these cases the correct thing to do is to shut down the voltage regulator output. We need to handle these faults.

Currently esp-miner doesn't do anything, and this is believe to be the cause of #588 

This PR is a WIP.

What I have so far:
- Monitoring the TPS546 Status registers and printing out the exact fault or warn if there is one.
- Clearing the status register bits

What needs TBD
- rename "overheat mode" into a more general "fault mode" and switch into it on the approriate faults, whether they are OT, OC, OV or UV. Chanve AxeOS to show these faults, and allow for clearing them.
- - develop a safer way to clear faults. It shouldn't be automatically done in every case.