### PR TITLE
Disable softap even if we don't have a valid model

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -125,9 +125,9 @@ void app_main(void)
 
     GLOBAL_STATE.new_stratum_version_rolling_msg = false;
 
-    if (GLOBAL_STATE.valid_model) {
-        wifi_softap_off();
+    wifi_softap_off();
 
+    if (GLOBAL_STATE.valid_model) {
         queue_init(&GLOBAL_STATE.stratum_queue);
         queue_init(&GLOBAL_STATE.ASIC_jobs_queue);
 


### PR DESCRIPTION
This allows us to flash the firmware using the web ui even if no valid model is found.