### PR TITLE
feat: unlock OC

### DIFF
--- a/main/http_server/axe-os/src/app/components/edit/edit.component.html
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="form != null">
     <form [formGroup]="form">
-        <ng-container *ngIf="!devToolsOpen && [eASICModel.BM1366, eASICModel.BM1368, eASICModel.BM1370, eASICModel.BM1397].includes(ASICModel)">
+        <ng-container *ngIf="!settingsUnlocked && [eASICModel.BM1366, eASICModel.BM1368, eASICModel.BM1370, eASICModel.BM1397].includes(ASICModel)">
             <div class="field grid p-fluid">
                 <label class="col-12 mb-2 md:col-2 md:mb-0" htmlFor="frequency">Frequency</label>
                 <div class="col-12 md:col-10">
@@ -16,7 +16,7 @@
             </div>
         </ng-container>
 
-        <ng-container *ngIf="devToolsOpen === true">
+        <ng-container *ngIf="settingsUnlocked === true">
 
             <div class="field grid p-fluid">
                 <label htmlFor="frequency" class="col-12 mb-2 md:col-2 md:mb-0">Frequency</label>

--- a/main/http_server/axe-os/src/app/components/edit/edit.component.ts
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.ts
@@ -20,7 +20,7 @@ export class EditComponent implements OnInit, OnDestroy {
   public websiteUpdateProgress: number | null = null;
 
   public savedChanges: boolean = false;
-  public devToolsOpen: boolean = false;
+  public settingsUnlocked: boolean = false;
   public eASICModel = eASICModel;
   public ASICModel!: eASICModel;
 
@@ -124,8 +124,11 @@ export class EditComponent implements OnInit, OnDestroy {
     private toastr: ToastrService,
     private loadingService: LoadingService
   ) {
-    window.addEventListener('resize', this.checkDevTools.bind(this));
-    this.checkDevTools();
+    // Add unlockSettings to window object for console access
+    (window as any).unlockSettings = () => {
+      this.settingsUnlocked = true;
+      console.log('Settings unlocked. You can now set custom frequency and voltage values.');
+    };
   }
 
   ngOnInit(): void {
@@ -161,20 +164,10 @@ export class EditComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    window.removeEventListener('resize', this.checkDevTools.bind(this));
+    // Remove unlockSettings from window object
+    delete (window as any).unlockSettings;
     this.destroy$.next();
     this.destroy$.complete();
-  }
-
-  private checkDevTools(): void {
-    if (
-      window.outerWidth - window.innerWidth > 160 ||
-      window.outerHeight - window.innerHeight > 160
-    ) {
-      this.devToolsOpen = true;
-    } else {
-      this.devToolsOpen = false;
-    }
   }
 
   public updateSystem() {

--- a/main/http_server/axe-os/src/app/components/settings/settings.component.ts
+++ b/main/http_server/axe-os/src/app/components/settings/settings.component.ts
@@ -22,7 +22,6 @@ export class SettingsComponent {
   public websiteUpdateProgress: number | null = null;
 
 
-  public devToolsOpen: boolean = false;
   public eASICModel = eASICModel;
   public ASICModel!: eASICModel;
 
@@ -44,9 +43,6 @@ export class SettingsComponent {
   ) {
 
 
-
-    window.addEventListener('resize', this.checkDevTools);
-    this.checkDevTools();
 
     this.latestRelease$ = this.githubUpdateService.getReleases().pipe(map(releases => {
       return releases[0];
@@ -93,17 +89,6 @@ export class SettingsComponent {
       });
 
   }
-  private checkDevTools = () => {
-    if (
-      window.outerWidth - window.innerWidth > 160 ||
-      window.outerHeight - window.innerHeight > 160
-    ) {
-      this.devToolsOpen = true;
-    } else {
-      this.devToolsOpen = false;
-    }
-  };
-
   public updateSystem() {
 
     const form = this.form.getRawValue();
@@ -136,7 +121,7 @@ export class SettingsComponent {
   otaUpdate(event: FileUploadHandlerEvent) {
     const file = event.files[0];
     this.firmwareUpload.clear(); // clear the file upload component
-    
+
     if (file.name != 'esp-miner.bin') {
       this.toastrService.error('Incorrect file, looking for esp-miner.bin.', 'Error');
       return;


### PR DESCRIPTION
this adds in the console function: "unlockSettings()" which can be used in the browser to unlock the settings and set custom values for frequency and voltage

it also removes the old devToolCheck which seems no longer to work on all browser