### PR TITLE
Fix stackoverflow when upgrading #674

### DIFF
--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -855,6 +855,7 @@ esp_err_t start_rest_server(void * pvParameters)
 
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
     config.uri_match_fn = httpd_uri_match_wildcard;
+    config.stack_size = 8192;
     config.max_open_sockets = 10;
     config.max_uri_handlers = 20;
 


### PR DESCRIPTION
This fixes #674 - It's possible to cause a stack overflow if upgrading the firmware and streaming logs at the same time.

```
I (37849) esp_image: segment 0: paddr=00b10020 vaddr=3c0e0020 size=2e738h (190264) map

***ERROR*** A stack overflow in task httpd has been detected.

Backtrace: 0x40375fc5:0x3fce0bc0 0x4037f151:0x3fce0be0 0x40380086:0x3fce0c00 0x403819d7:0x3fce0c80 0x4038014c:0x3fce0ca0 0x40380142:0x40377ae1 |<-CORRUPTED
--- 0x40375fc5: panic_enable_cache at /opt/esp/idf/components/esp_system/port/panic_handler.c:233
0x4037f151: prvCopyDataToQueue at /opt/esp/idf/components/freertos/FreeRTOS-Kernel/queue.c:2460
0x40380086: _frxt_int_exit at /opt/esp/idf/components/freertos/FreeRTOS-Kernel/portable/xtensa/portasm.S:199
0x403819d7: vTaskRemoveFromUnorderedEventList at /opt/esp/idf/components/freertos/FreeRTOS-Kernel/tasks.c:4123
0x4038014c: vPortYield at /opt/esp/idf/components/freertos/FreeRTOS-Kernel/portable/xtensa/portasm.S:572
0x40380142: vPortYield at /opt/esp/idf/components/freertos/FreeRTOS-Kernel/portable/xtensa/portasm.S:559
0x40377ae1: _xt_lowint1 at /opt/esp/idf/components/xtensa/xtensa_vectors.S:1240
```