### PR TITLE
fix: typo in .filter

### DIFF
--- a/main/http_server/axe-os/src/app/components/edit/edit.component.ts
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.ts
@@ -24,7 +24,7 @@ export class EditComponent implements OnInit, OnDestroy {
   public eASICModel = eASICModel;
   public ASICModel!: eASICModel;
   public restrictedModels: eASICModel[] = Object.values(eASICModel)
-    .filter((v): v is eASICModel => typeof v === 'number');
+    .filter((v): v is eASICModel => typeof v === 'string');
 
   @Input() uri = '';
 


### PR DESCRIPTION
I was filtering for number while the enum are string