### PR TITLE
Trim spaces from SSID

### DIFF
--- a/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.ts
+++ b/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.ts
@@ -62,6 +62,11 @@ export class NetworkEditComponent implements OnInit {
       delete form.wifiPass;
     }
 
+    // Trim SSID to remove any leading/trailing whitespace
+    if (form.ssid) {
+      form.ssid = form.ssid.trim();
+    }
+
     this.systemService.updateSystem(this.uri, form)
       .pipe(this.loadingService.lockUIUntilComplete())
       .subscribe({


### PR DESCRIPTION
I noticed a while ago that the string inputs are not trimmed of spaces. This can cause, in my use-case, issues with the SSID not matching when typing the SSID in manually from a phone when the word Bitcoin is auto-completed.  This PR simply trims the SSID input on the API and client side. I only did this for the SSID for now to simplify the initial PR, since this concept could, and perhaps _should_, be expanded to the other string inputs. This expansion would probably also help with #565.