### PR TITLE
add sorting switch to swarm page for hostname and ip

### DIFF
--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
@@ -24,8 +24,8 @@
     <div class="flex align-items-center gap-2">
         <label for="refresh-interval" class="text-sm md:text-base">Refresh Interval:</label>
         <p-slider id="refresh-interval" class="pl-2 pr-2"
-                 [min]="5" 
-                 [max]="30" 
+                 [min]="5"
+                 [max]="30"
                  [style]="{'width': '150px'}"
                  [formControl]="refreshIntervalControl">
         </p-slider>
@@ -48,7 +48,26 @@
 <div class="table-container">
     <table cellspacing="0" cellpadding="0" class="text-sm md:text-base">
         <tr>
-            <th>IP</th>
+            <th>
+                <div class="flex items-center cursor-pointer select-none h-full" (click)="sortBy('IP')">
+                    <span class="flex-1">IP</span>
+                    <i class="pi text-xs flex items-center" [ngClass]="{
+                        'pi-sort-alt': sortField !== 'IP',
+                        'pi-sort-amount-up-alt': sortField === 'IP' && sortDirection === 'asc',
+                        'pi-sort-amount-down': sortField === 'IP' && sortDirection === 'desc'
+                    }"></i>
+                </div>
+            </th>
+            <th>
+                <div class="flex items-center cursor-pointer select-none h-full" (click)="sortBy('hostname')">
+                    <span class="flex-1">Hostname</span>
+                    <i class="pi text-xs flex items-center" [ngClass]="{
+                        'pi-sort-alt': sortField !== 'hostname',
+                        'pi-sort-amount-up-alt': sortField === 'hostname' && sortDirection === 'asc',
+                        'pi-sort-amount-down': sortField === 'hostname' && sortDirection === 'desc'
+                    }"></i>
+                </div>
+            </th>
             <th>Hash Rate</th>
             <th>Uptime</th>
             <th>Shares</th>
@@ -72,21 +91,21 @@
                             axe.ASICModel === 'BM1370' ? 'text-green-500' :
                             ''
                        ]"
-                       [href]="'http://'+axe.IP" 
+                       [href]="'http://'+axe.IP"
                        target="_blank"
                        [pTooltip]="axe.ASICModel"
                        tooltipPosition="top">{{axe.IP}}</a>
-                    <div class="text-sm">{{axe.hostname}}</div>
                 </td>
+                <td>{{axe.hostname}}</td>
                 <td>{{axe.hashRate * 1000000000 | hashSuffix}}</td>
                 <td>{{axe.uptimeSeconds | dateAgo: {intervals: 2} }}</td>
                 <td>
-                    <div class="w-min cursor-pointer" 
+                    <div class="w-min cursor-pointer"
                          pTooltip="Shares Accepted"
                          tooltipPosition="top">
                         {{axe.sharesAccepted | number: '1.0-0'}}
                     </div>
-                    <div class="text-sm w-min cursor-pointer" 
+                    <div class="text-sm w-min cursor-pointer"
                          pTooltip="Shares Rejected"
                          tooltipPosition="top">
                         {{axe.sharesRejected | number: '1.0-0'}}
@@ -97,8 +116,8 @@
                     <div [ngClass]="{'text-orange-500': axe.temp > 68}">
                         {{axe.temp | number: '1.0-1'}}°<small>C</small>
                     </div>
-                    <div class="text-sm w-min cursor-pointer" 
-                         [ngClass]="{'text-orange-500': axe.vrTemp > 90}" 
+                    <div class="text-sm w-min cursor-pointer"
+                         [ngClass]="{'text-orange-500': axe.vrTemp > 90}"
                          *ngIf="axe.vrTemp"
                          pTooltip="Voltage Regulator Temperature"
                          tooltipPosition="top">
@@ -107,14 +126,14 @@
                 </td>
                 <td>
                     <div>{{axe.bestDiff}}</div>
-                    <div class="text-sm w-min cursor-pointer" 
+                    <div class="text-sm w-min cursor-pointer"
                          pTooltip="Best Session Diff"
                          tooltipPosition="top">
                         {{axe.bestSessionDiff}}
                     </div>
                 </td>
                 <td>{{axe.version}}</td>
-             <td><p-button icon="pi pi-pencil" pp-button (click)="edit(axe)"></p-button></td>
+                <td><p-button icon="pi pi-pencil" pp-button (click)="edit(axe)"></p-button></td>
                 <td><p-button icon="pi pi-sync" pp-button severity="danger" (click)="restart(axe)"></p-button></td>
                 <td><p-button icon="pi pi-trash" pp-button severity="secondary" (click)="remove(axe)"></p-button></td>
             </tr>

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.scss
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.scss
@@ -6,13 +6,38 @@ table {
 th {
     text-align: left;
     background-color: #1f2d40;
+    padding: 0;
+    
+    > div {
+        height: 100%;
+        padding: 0.5rem 1rem;
+        gap: 0.75rem;
+    }
+    
+    .pi {
+        opacity: 0.7;
+        height: 1em;
+        line-height: 1;
+        
+        &.pi-sort-amount-up-alt,
+        &.pi-sort-amount-down {
+            opacity: 1;
+        }
+    }
 }
-
 
 th,
 td {
-    padding: 1rem 1rem;
     border-bottom: 1px solid #304562;
+}
+
+td {
+    padding: 1rem;
+}
+
+th > div {
+    min-width: 100px; 
+    padding-right: 0.5rem;
 }
 
 a {

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -33,6 +33,9 @@ export class SwarmComponent implements OnInit, OnDestroy {
 
   public refreshIntervalControl: FormControl;
 
+  public sortField: string = '';
+  public sortDirection: 'asc' | 'desc' = 'asc';
+
   constructor(
     private fb: FormBuilder,
     private systemService: SystemService,
@@ -240,6 +243,35 @@ export class SwarmComponent implements OnInit, OnDestroy {
 
   private sortByIp(a: any, b: any): number {
     return this.ipToInt(a.IP) - this.ipToInt(b.IP);
+  }
+
+  sortBy(field: string) {
+    // If clicking the same field, toggle direction
+    if (this.sortField === field) {
+      this.sortDirection = this.sortDirection === 'asc' ? 'desc' : 'asc';
+    } else {
+      // New field, set to ascending by default
+      this.sortField = field;
+      this.sortDirection = 'asc';
+    }
+
+    this.swarm.sort((a, b) => {
+      let comparison = 0;
+      if (field === 'IP') {
+        // Split IP into octets and compare numerically
+        const aOctets = a[field].split('.').map(Number);
+        const bOctets = b[field].split('.').map(Number);
+        for (let i = 0; i < 4; i++) {
+          if (aOctets[i] !== bOctets[i]) {
+            comparison = aOctets[i] - bOctets[i];
+            break;
+          }
+        }
+      } else {
+        comparison = a[field].localeCompare(b[field], undefined, { numeric: true });
+      }
+      return this.sortDirection === 'asc' ? comparison : -comparison;
+    });
   }
 
   private convertBestDiffToNumber(bestDiff: string): number {


### PR DESCRIPTION
this adds a sorting functionality to the table on the swarm page for sorting by IP or hostname. 

it adds icons on the swarm page as well.

![image](https://github.com/user-attachments/assets/2e1abed8-325c-4736-8144-a2d5cb90fa8a)

closes #725 