### PR TITLE
Prompt for restart only when needed

### DIFF
--- a/main/http_server/axe-os/src/app/components/edit/edit.component.html
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.html
@@ -81,13 +81,12 @@
         <div class="mt-2">
             <button pButton [disabled]="!form.dirty || form.invalid" (click)="updateSystem()"
                 class="btn btn-primary mr-2">Save</button>
-            <b style="line-height: 34px;">You must restart this device after saving for changes to take effect.</b>
+            <button pButton [disabled]="!savedChanges" *ngIf="requiresRestart()" (click)="restart()">Restart</button>
         </div>
 
         <div class="mt-2">
-            <button pButton [disabled]="!savedChanges" (click)="restart()">Restart</button>
+            <b style="line-height: 34px;" *ngIf="requiresRestart()">You must restart this device after saving for changes to take effect.</b>
         </div>
-
 
     </form>
 </ng-container>

--- a/main/http_server/axe-os/src/app/components/edit/edit.component.ts
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.ts
@@ -206,6 +206,14 @@ export class EditComponent implements OnInit, OnDestroy {
     this.updateSystem();
   }
 
+  public requiresRestart(): boolean {
+    if (!this.form) return false;
+    const flipscreen = this.form.get('flipscreen');
+    const invertscreen = this.form.get('invertscreen');
+    const invertfanpolarity = this.form.get('invertfanpolarity');
+    return (flipscreen?.dirty || invertscreen?.dirty || invertfanpolarity?.dirty) ?? false;
+  }
+
   public restart() {
     this.systemService.restart(this.uri)
       .pipe(this.loadingService.lockUIUntilComplete())

--- a/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.html
+++ b/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.html
@@ -29,11 +29,11 @@
         <div class="mt-2">
             <button pButton [disabled]="!form.dirty || form.invalid" (click)="updateSystem()"
                 class="btn btn-primary mr-2">Save</button>
-            <b style="line-height: 34px;">You must restart this device after saving for changes to take effect.</b>
+            <button pButton [disabled]="!savedChanges" *ngIf="requiresRestart()" (click)="restart()">Restart</button>
         </div>
 
         <div class="mt-2">
-            <button pButton [disabled]="!savedChanges" (click)="restart()">Restart</button>
+            <b style="line-height: 34px;" *ngIf="requiresRestart()">You must restart this device after saving for changes to take effect.</b>
         </div>
     </form>
 </ng-container>

--- a/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.ts
+++ b/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.ts
@@ -127,6 +127,13 @@ export class NetworkEditComponent implements OnInit {
       });
   }
 
+  public requiresRestart(): boolean {
+    if (!this.form) return false;
+    const ssid = this.form.get('ssid');
+    const password = this.form.get('wifiPass');
+    return (ssid?.dirty || password?.dirty) ?? false;
+  }
+
   public restart() {
     this.systemService.restart()
       .pipe(this.loadingService.lockUIUntilComplete())

--- a/main/http_server/axe-os/src/app/components/pool/pool.component.html
+++ b/main/http_server/axe-os/src/app/components/pool/pool.component.html
@@ -71,11 +71,11 @@
         <div class="mt-2">
             <button pButton [disabled]="!form.dirty || form.invalid" (click)="updateSystem()"
                 class="btn btn-primary mr-2">Save</button>
-            <b style="line-height: 34px;">You must restart this device after saving for changes to take effect.</b>
+            <button pButton [disabled]="!savedChanges" (click)="restart()">Restart</button>
         </div>
 
         <div class="mt-2">
-          <button pButton [disabled]="!savedChanges" (click)="restart()">Restart</button>
+          <b style="line-height: 34px;">You must restart this device after saving for changes to take effect.</b>
         </div>
             </form>
         </div>

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -64,7 +64,7 @@ export class SystemService {
 
           boardtemp1: 30,
           boardtemp2: 40,
-          overheat_mode: 0
+          overheat_mode: 1
         }
       ).pipe(delay(1000));
     }
@@ -75,7 +75,11 @@ export class SystemService {
   }
 
   public updateSystem(uri: string = '', update: any) {
-    return this.httpClient.patch(`${uri}/api/system`, update);
+    if (environment.production) {
+      return this.httpClient.patch(`${uri}/api/system`, update);
+    } else {
+      return of(true);
+    }
   }
 
 


### PR DESCRIPTION
Closes #581 

Only prompt for restart when it's needed.  The only question is on hostname. Technically restart isn't needed but it won't take until a dhcp lease renewal.  Also think the buttons look better lined up.

<img width="458" alt="image" src="https://github.com/user-attachments/assets/5f7da701-c28f-49ab-9e04-fb59a04465b6" />

---

This is the list I've identified that requires restart (Y)

# Network

Hostname: ?
SSID: Y
Wifi-Pass: Y

# Pool Configuation

All pool settings require restart

# Settings

Frequency: N
Core Voltage: N
Flip Screen: Y
Invert Fan Polarity: Y
AutoMatic Fan Control: N
Fan Speed: N
Overheat Mode: N