### PR TITLE
Show share reject reasons

### DIFF
--- a/components/stratum/stratum_api.c
+++ b/components/stratum/stratum_api.c
@@ -137,12 +137,15 @@ void STRATUM_V1_parse(StratumApiV1Message * message, const char * stratum_json)
         cJSON * error_json = cJSON_GetObjectItem(json, "error");
         cJSON * reject_reason_json = cJSON_GetObjectItem(json, "reject-reason");
 
-        //if the result is null, then it's a fail
+        // if the result is null, then it's a fail
         if (result_json == NULL) {
             message->response_success = false;
-
-        //if it's an error, then it's a fail
+            message->error_str = strdup("unknown");
+            
+        // if it's an error, then it's a fail
         } else if (!cJSON_IsNull(error_json)) {
+            message->response_success = false;
+            message->error_str = strdup("unknown");
             if (parsed_id < 5) {
                 result = STRATUM_RESULT_SETUP;
             } else {
@@ -157,9 +160,8 @@ void STRATUM_V1_parse(StratumApiV1Message * message, const char * stratum_json)
                     }
                 }
             }
-            message->response_success = false;
 
-        //if the result is a boolean, then parse it
+        // if the result is a boolean, then parse it
         } else if (cJSON_IsBool(result_json)) {
             if (parsed_id < 5) {
                 result = STRATUM_RESULT_SETUP;
@@ -170,6 +172,7 @@ void STRATUM_V1_parse(StratumApiV1Message * message, const char * stratum_json)
                 message->response_success = true;
             } else {
                 message->response_success = false;
+                message->error_str = "unknown";
                 if (cJSON_IsString(reject_reason_json)) {
                     message->error_str = strdup(cJSON_GetStringValue(reject_reason_json));
                 }                

--- a/components/stratum/stratum_api.c
+++ b/components/stratum/stratum_api.c
@@ -172,7 +172,7 @@ void STRATUM_V1_parse(StratumApiV1Message * message, const char * stratum_json)
                 message->response_success = true;
             } else {
                 message->response_success = false;
-                message->error_str = "unknown";
+                message->error_str = strdup("unknown");
                 if (cJSON_IsString(reject_reason_json)) {
                     message->error_str = strdup(cJSON_GetStringValue(reject_reason_json));
                 }                

--- a/main/global_state.h
+++ b/main/global_state.h
@@ -49,6 +49,11 @@ typedef enum
 //     void (*set_version_mask)(uint32_t);
 // } AsicFunctions;
 
+typedef struct {
+    char message[64];
+    uint32_t count;
+} RejectedReasonStat;
+
 typedef struct
 {
     double duration_start;
@@ -60,6 +65,8 @@ typedef struct
     int64_t start_time;
     uint64_t shares_accepted;
     uint64_t shares_rejected;
+    RejectedReasonStat rejected_reason_stats[10];
+    int rejected_reason_stats_count;
     int screen_page;
     uint64_t best_nonce_diff;
     char best_diff_string[DIFF_STRING_SIZE];

--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -73,8 +73,17 @@
                                 </div>
                             </div>
                         </div>
-                        <span class="text-red-500 font-medium">{{info.sharesRejected | number: '1.0-0'}} </span>
-                        <span class="text-500">rejected</span> <span class="font-medium"> ({{(info.sharesRejected / (info.sharesAccepted + info.sharesRejected) * 100) | number: '1.2-2'}}%)</span>
+                        <div *ngIf="info.sharesRejected === 0">
+                            <span class="text-red-500 font-medium">0 </span>
+                            <span class="text-500">rejected</span>
+                        </div>
+                        <div *ngIf="info.sharesRejected > 0">
+                            <div *ngFor="let sharesRejectedReason of info.sharesRejectedReasons">
+                                <span class="text-red-500 font-medium">{{sharesRejectedReason.count | number: '1.0-0'}} </span>
+                                <span class="text-500">{{sharesRejectedReason.message}}</span>
+                                ({{(sharesRejectedReason.count / (info.sharesAccepted + info.sharesRejected) * 100) | number: '1.2-2'}}%)
+                            </div>
+                        </div>                        
                     </div>
                 </div>
 

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -40,6 +40,7 @@ export class SystemService {
           apEnabled: 0,
           sharesAccepted: 1,
           sharesRejected: 0,
+          sharesRejectedReasons: [],
           uptimeSeconds: 38,
           asicCount: 1,
           smallCoreCount: 672,

--- a/main/http_server/axe-os/src/models/ISystemInfo.ts
+++ b/main/http_server/axe-os/src/models/ISystemInfo.ts
@@ -1,5 +1,10 @@
 import { eASICModel } from './enum/eASICModel';
 
+interface ISharesRejectedStat {
+    message: string;
+    count: number;
+}
+
 export interface ISystemInfo {
 
     flipscreen: number;
@@ -21,6 +26,7 @@ export interface ISystemInfo {
     apEnabled: number,
     sharesAccepted: number,
     sharesRejected: number,
+    sharesRejectedReasons: ISharesRejectedStat[];
     uptimeSeconds: number,
     asicCount: number,
     smallCoreCount: number,

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -560,6 +560,17 @@ static esp_err_t GET_system_info(httpd_req_t * req)
     cJSON_AddNumberToObject(root, "apEnabled", GLOBAL_STATE->SYSTEM_MODULE.ap_enabled);
     cJSON_AddNumberToObject(root, "sharesAccepted", GLOBAL_STATE->SYSTEM_MODULE.shares_accepted);
     cJSON_AddNumberToObject(root, "sharesRejected", GLOBAL_STATE->SYSTEM_MODULE.shares_rejected);
+
+    cJSON *error_array = cJSON_CreateArray();
+    cJSON_AddItemToObject(root, "sharesRejectedReasons", error_array);
+    
+    for (int i = 0; i < GLOBAL_STATE->SYSTEM_MODULE.rejected_reason_stats_count; i++) {
+        cJSON *error_obj = cJSON_CreateObject();
+        cJSON_AddStringToObject(error_obj, "message", GLOBAL_STATE->SYSTEM_MODULE.rejected_reason_stats[i].message);
+        cJSON_AddNumberToObject(error_obj, "count", GLOBAL_STATE->SYSTEM_MODULE.rejected_reason_stats[i].count);
+        cJSON_AddItemToArray(error_array, error_obj);
+    }
+
     cJSON_AddNumberToObject(root, "uptimeSeconds", (esp_timer_get_time() - GLOBAL_STATE->SYSTEM_MODULE.start_time) / 1000000);
     cJSON_AddNumberToObject(root, "asicCount", ASIC_get_asic_count(GLOBAL_STATE));
     cJSON_AddNumberToObject(root, "smallCoreCount", ASIC_get_small_core_count(GLOBAL_STATE));

--- a/main/system.h
+++ b/main/system.h
@@ -7,7 +7,7 @@ void SYSTEM_init_system(GlobalState * GLOBAL_STATE);
 void SYSTEM_init_peripherals(GlobalState * GLOBAL_STATE);
 
 void SYSTEM_notify_accepted_share(GlobalState * GLOBAL_STATE);
-void SYSTEM_notify_rejected_share(GlobalState * GLOBAL_STATE);
+void SYSTEM_notify_rejected_share(GlobalState * GLOBAL_STATE, char * error_msg);
 void SYSTEM_notify_found_nonce(GlobalState * GLOBAL_STATE, double found_diff, uint8_t job_id);
 void SYSTEM_notify_mining_started(GlobalState * GLOBAL_STATE);
 void SYSTEM_notify_new_ntime(GlobalState * GLOBAL_STATE, uint32_t ntime);

--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -342,8 +342,8 @@ void stratum_task(void * pvParameters)
                     ESP_LOGI(TAG, "message result accepted");
                     SYSTEM_notify_accepted_share(GLOBAL_STATE);
                 } else {
-                    ESP_LOGW(TAG, "message result rejected: %s", stratum_api_v1_message.error_str ? stratum_api_v1_message.error_str : "unknown");
-                    SYSTEM_notify_rejected_share(GLOBAL_STATE);
+                    ESP_LOGW(TAG, "message result rejected: %s", stratum_api_v1_message.error_str);
+                    SYSTEM_notify_rejected_share(GLOBAL_STATE, stratum_api_v1_message.error_str);
                 }
             } else if (stratum_api_v1_message.method == STRATUM_RESULT_SETUP) {
                 // Reset retry attempts after successfully receiving data.
@@ -351,7 +351,7 @@ void stratum_task(void * pvParameters)
                 if (stratum_api_v1_message.response_success) {
                     ESP_LOGI(TAG, "setup message accepted");
                 } else {
-                    ESP_LOGE(TAG, "setup message rejected: %s", stratum_api_v1_message.error_str ? stratum_api_v1_message.error_str : "unknown");
+                    ESP_LOGE(TAG, "setup message rejected: %s", stratum_api_v1_message.error_str);
                 }
             }
         }


### PR DESCRIPTION
Example from ckpool:

![image](https://github.com/user-attachments/assets/5ce1f223-f53b-4c95-a938-1ec49d0d09f5)

Example from public-pool:

![image](https://github.com/user-attachments/assets/3590af21-b835-4e96-927b-04942667b7af)

Reject reasons are pool software specific, so this is different per pool. See the linked issue for some messages.

Fixes #264