### PR TITLE
Fix difficulty adjustment

### DIFF
--- a/main/tasks/asic_task.c
+++ b/main/tasks/asic_task.c
@@ -50,7 +50,6 @@ void ASIC_task(void *pvParameters)
         if (current_connection->stratum_difficulty != next_bm_job->pool_diff)
         {
             ESP_LOGI(TAG, "New pool difficulty %lu", next_bm_job->pool_diff);
-            current_connection->stratum_difficulty = next_bm_job->pool_diff;
         }
 
         pthread_mutex_lock(&current_connection->jobs_lock);

--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -162,7 +162,7 @@ void stratum_clear_queue(const char * POOL_TAG, StratumConnection * connection)
     queue_clear(&connection->stratum_queue);
 
     pthread_mutex_lock(&connection->jobs_lock);
-    for (int i = 0; i < 128; i = i + 4) {
+    for (int i = 0; i < 128; i++) {
         connection->jobs[i] = 0;
     }
     pthread_mutex_unlock(&connection->jobs_lock);
@@ -323,11 +323,15 @@ void stratum_process(const char * POOL_TAG, GlobalState * GLOBAL_STATE, StratumC
         }
         else if (connection->message->method == MINING_SET_DIFFICULTY)
         {
+            pthread_mutex_lock(&connection->jobs_lock);
+
             if (connection->stratum_difficulty != connection->message->new_difficulty)
             {
                 connection->stratum_difficulty = connection->message->new_difficulty;
                 ESP_LOGI(POOL_TAG, "Set stratum difficulty: %ld", connection->stratum_difficulty);
             }
+
+            pthread_mutex_unlock(&connection->jobs_lock);
         }
         else if (connection->message->method == MINING_SET_VERSION_MASK ||
                 connection->message->method == STRATUM_RESULT_VERSION_MASK)


### PR DESCRIPTION
I think this fixes the difficulty adjustment race condition, at least when testing on public-pool and ckpool.

The main point is the removal of 
```
current_connection->stratum_difficulty = next_bm_job->pool_diff;
```
in `asic_task.c`. The other point is adding the same mutex around `MINING_SET_DIFFICULTY` in `stratum_task.c`.

Public-pool is easy, as they request a queue clear whenever the difficulty changes. Ckpool doesn't, however it does complain for a while (about 1 minute or so), this is the same as it was before.

---

Addition: I now see the discussion on #717, so this is moot I guess, unless parts of this code will be salvaged without the secondary_pool being opened.