### PR TITLE
Fixing TPS546D24 phase register default value

### DIFF
--- a/main/power/TPS546.h
+++ b/main/power/TPS546.h
@@ -21,7 +21,7 @@
 #define OPERATION_OFF 0x00
 #define OPERATION_ON  0x80
 
-#define TPS546_INIT_PHASE 0x00  /* phase */
+#define TPS546_INIT_PHASE 0xFF  /* default phase register value from TPS546 datasheet */
 
 #define TPS546_INIT_FREQUENCY 650  /* KHz */
 


### PR DESCRIPTION
**Tested on:** Bitaxe Gamma GT (800x aka Gamma Turbo)

**Issue:** Core voltage regulator (TPS546D24 stack) fails to startup properly - status remains 0x0840 (UNIT_OFF).
**Root cause:** The driver sets the PHASE register (PMBus command 0x04) to 0x00, which restricts all following commands to phase 1 only. This causes phase 2 to remain unconfigured and OFF.

**Fix (TPS546.h):**
```
-#define TPS546_INIT_PHASE 0x00  /* phase */
+#define TPS546_INIT_PHASE 0xFF  /* default phase register value from TPS546 datasheet */
```

This ensures all global configuration commands apply to both phases, as required in a multi-phase stack. According to the TPS546D24 datasheet, the default value of the PHASE register is 0xFF (broadcast mode).
Later in the same driver, the line `smb_write_byte(PMBUS_PHASE, TPS546_INIT_PHASE);` is labeled "set back to default", but actually sets it to 0x00, not the real default 0xFF.