### PR TITLE
fix: process dirs recursively

### DIFF
--- a/main/http_server/axe-os/only-gzip.js
+++ b/main/http_server/axe-os/only-gzip.js
@@ -3,28 +3,29 @@ const path = require('path');
 
 const directory = './dist/axe-os';
 
-fs.readdir(directory, (err, files) => {
-    if (err) throw err;
+function processDirectory(dirPath) {
+    fs.readdir(dirPath, (err, files) => {
+        if (err) throw err;
 
-    for (const file of files) {
-        const filePath = path.join(directory, file);
+        for (const file of files) {
+            const filePath = path.join(dirPath, file);
 
-        fs.stat(filePath, (err, stats) => {
-            if (err) throw err;
+            fs.stat(filePath, (err, stats) => {
+                if (err) throw err;
 
-            if (stats.isDirectory()) {
-                // If it's a directory, call rmdir after deleting its contents
-                fs.rm(filePath, { recursive: true }, (err) => {
-                    if (err) throw err;
-                    console.log(`Removed directory: ${filePath}`);
-                });
-            } else if (!file.endsWith('.gz')) {
-                // If it's a file and doesn't end with .gz, unlink it
-                fs.unlink(filePath, (err) => {
-                    if (err) throw err;
-                    console.log(`Removed file: ${filePath}`);
-                });
-            }
-        });
-    }
-});
+                if (stats.isDirectory()) {
+                    // If it's a directory, process it recursively
+                    processDirectory(filePath);
+                } else if (!file.endsWith('.gz')) {
+                    // If it's a file and doesn't end with .gz, unlink it
+                    fs.unlink(filePath, (err) => {
+                        if (err) throw err;
+                        console.log(`Removed file: ${filePath}`);
+                    });
+                }
+            });
+        }
+    });
+}
+
+processDirectory(directory);


### PR DESCRIPTION
Font files (AngelWish.woff2, Nippo-Regular.woff2, primeicons.woff2) will now be properly gzipped and served
Eliminates the 302 redirects that were preventing font loading
Resolves the "Failed to decode downloaded font" and "OTS parsing error" issues
Maintains the build optimization while preserving necessary assets