### PR TITLE
reduce gap between hamburger and logo in AxeOS

### DIFF
--- a/main/http_server/axe-os/src/app/layout/styles/layout/_topbar.scss
+++ b/main/http_server/axe-os/src/app/layout/styles/layout/_topbar.scss
@@ -6,6 +6,7 @@
     top: 0;
     width: 100%;
     padding: 0 2rem;
+    gap: 1rem;
     background-color: var(--surface-card);
     transition: left $transitionDuration;
     display: flex;


### PR DESCRIPTION
old: 
![image](https://github.com/user-attachments/assets/cbad889a-57cf-40e2-99fd-9cab14b3055d)

new: 
![image](https://github.com/user-attachments/assets/5184c88e-3ba2-499f-932e-649b055f52c6)

doesnt need anything done for the smaller scales