### PR TITLE
Increased contrast ratio for purple

### DIFF
--- a/main/http_server/axe-os/src/app/components/design/theme-config.component.ts
+++ b/main/http_server/axe-os/src/app/components/design/theme-config.component.ts
@@ -184,31 +184,31 @@ export class ThemeConfigComponent implements OnInit {
     },
     {
       name: 'Purple',
-      primaryColor: '#9c27b0',
+      primaryColor: '#b340fa',
       accentColors: {
-        '--primary-color': '#9c27b0',
+        '--primary-color': '#b340fa',
         '--primary-color-text': '#ffffff',
-        '--highlight-bg': '#9c27b0',
+        '--highlight-bg': '#b340fa',
         '--highlight-text-color': '#ffffff',
         '--focus-ring': '0 0 0 0.2rem rgba(156,39,176,0.2)',
         // PrimeNG Slider
         '--slider-bg': '#dee2e6',
-        '--slider-range-bg': '#9c27b0',
-        '--slider-handle-bg': '#9c27b0',
+        '--slider-range-bg': '#b340fa',
+        '--slider-handle-bg': '#b340fa',
         // Progress Bar
         '--progressbar-bg': '#dee2e6',
-        '--progressbar-value-bg': '#9c27b0',
+        '--progressbar-value-bg': '#b340fa',
         // PrimeNG Checkbox
-        '--checkbox-border': '#9c27b0',
-        '--checkbox-bg': '#9c27b0',
+        '--checkbox-border': '#b340fa',
+        '--checkbox-bg': '#b340fa',
         '--checkbox-hover-bg': '#8e24aa',
         // PrimeNG Button
-        '--button-bg': '#9c27b0',
+        '--button-bg': '#b340fa',
         '--button-hover-bg': '#8e24aa',
-        '--button-focus-shadow': '0 0 0 2px #ffffff, 0 0 0 4px #9c27b0',
+        '--button-focus-shadow': '0 0 0 2px #ffffff, 0 0 0 4px #b340fa',
         // Toggle button
-        '--togglebutton-bg': '#9c27b0',
-        '--togglebutton-border': '1px solid #9c27b0',
+        '--togglebutton-bg': '#b340fa',
+        '--togglebutton-border': '1px solid #b340fa',
         '--togglebutton-hover-bg': '#8e24aa',
         '--togglebutton-hover-border': '1px solid #8e24aa',
         '--togglebutton-text-color': '#ffffff'

--- a/main/http_server/axe-os/src/app/layout/styles/theme/themes/vela/_variables.scss
+++ b/main/http_server/axe-os/src/app/layout/styles/theme/themes/vela/_variables.scss
@@ -8,7 +8,7 @@ $colors: (
     "teal": #009688,
     "orange": #f57c00,
     "bluegray": #607d8b,
-    "purple": #9c27b0,
+    "purple": #b340fa,
     "red": #ff4032,
     "primary": $primaryColor,
 ) !default;


### PR DESCRIPTION
The Google Accessibility Tool suggests increasing the contrast of the purple color (current contrast ratio: 2.98, recommended contrast ratio: 4.5) to make the layout easier to read. This PR uses a slightly brighter purple to improve contrast.

**Before**
<img width="410" alt="Screenshot 2025-06-26 at 14 12 56" src="https://github.com/user-attachments/assets/13e94e3c-b203-44de-ae7e-9712f69b31df" />

**After**
<img width="394" alt="Screenshot 2025-06-26 at 14 12 26" src="https://github.com/user-attachments/assets/33db03be-5bdf-43d8-9086-ecb4b98abec6" />

