### PR TITLE
Auto refresh current version @ update view

### DIFF
--- a/main/http_server/axe-os/src/app/components/update/update.component.ts
+++ b/main/http_server/axe-os/src/app/components/update/update.component.ts
@@ -1,5 +1,5 @@
 import { Component, ViewChild } from '@angular/core';
-import { Observable, switchMap, shareReplay, map, timer } from 'rxjs';
+import { Observable, switchMap, shareReplay, map, timer, distinctUntilChanged } from 'rxjs';
 import { HttpErrorResponse, HttpEventType } from '@angular/common/http';
 import { ToastrService } from 'ngx-toastr';
 import { FileUploadHandlerEvent, FileUpload } from 'primeng/fileupload';
@@ -40,6 +40,7 @@ export class UpdateComponent {
 
     this.info$ = timer(0, 5000).pipe(
       switchMap(() => this.systemService.getInfo()),
+      distinctUntilChanged((prev, curr) => JSON.stringify(prev) === JSON.stringify(curr)),
       shareReplay(1)
     );
   }


### PR DESCRIPTION
The `update` page does not reload after the firmware update (AxeOS update does). This means that the display of the current version does not change after the firmware update. This PR makes sure that the version is checked in the background and refreshed on update.

<img width="478" alt="Screenshot 2025-07-02 at 22 30 25" src="https://github.com/user-attachments/assets/d383e307-b4e5-4240-911d-8f3a1faa2ea1" />
