### PR TITLE
Fix form labels

### DIFF
--- a/main/http_server/axe-os/src/app/components/edit/edit.component.html
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.html
@@ -5,21 +5,45 @@
         </p-message>
 
         <div class="field grid p-fluid">
-            <label htmlFor="frequency" class="col-12 md:col-2 md:m-0">Frequency</label>
-            <div class="col-12 md:col-10">
-                <input *ngIf="settingsUnlocked" pInputText id="frequency" formControlName="frequency" type="number" />
-                <p-dropdown *ngIf="!settingsUnlocked" [options]="dropdownFrequency" optionLabel="name" optionValue="value"
-                    formControlName="frequency"></p-dropdown>
-            </div>
+            <ng-container *ngIf="settingsUnlocked">
+                <label for="frequency" class="col-12 md:col-2 md:m-0">Frequency</label>
+                <div class="col-12 md:col-10">
+                    <input pInputText id="frequency" formControlName="frequency" type="number" />
+                </div>
+            </ng-container>
+            <ng-container *ngIf="!settingsUnlocked">
+                <label (click)="frequencyDropdown.show()" class="col-12 md:col-2 md:m-0 hover-next-input">Frequency</label>
+                <div class="col-12 md:col-10">
+                    <p-dropdown
+                        [options]="dropdownFrequency"
+                        optionLabel="name"
+                        optionValue="value"
+                        formControlName="frequency"
+                        #frequencyDropdown
+                    ></p-dropdown>
+                </div>
+            </ng-container>
         </div>
 
         <div class="field grid p-fluid">
-            <label htmlFor="coreVoltage" class="col-12 md:col-2 md:m-0">Core Voltage</label>
-            <div class="col-12 md:col-10">
-                <input *ngIf="settingsUnlocked" pInputText id="coreVoltage" formControlName="coreVoltage" type="number" />
-                <p-dropdown *ngIf="!settingsUnlocked" [options]="dropdownVoltage" optionLabel="name"
-                optionValue="value" formControlName="coreVoltage"></p-dropdown>
-            </div>
+            <ng-container *ngIf="settingsUnlocked">
+                <label for="coreVoltage" class="col-12 md:col-2 md:m-0">Core Voltage</label>
+                <div class="col-12 md:col-10">
+                    <input pInputText id="coreVoltage" formControlName="coreVoltage" type="number" />
+                </div>
+            </ng-container>
+            <ng-container *ngIf="!settingsUnlocked">
+                <label (click)="voltageDropdown.show()" class="col-12 md:col-2 md:m-0 hover-next-input">Core Voltage</label>
+                <div class="col-12 md:col-10">
+                    <p-dropdown
+                        [options]="dropdownVoltage"
+                        optionLabel="name"
+                        optionValue="value"
+                        formControlName="coreVoltage"
+                        #voltageDropdown
+                    ></p-dropdown>
+                </div>
+            </ng-container>
         </div>
 
         <div *ngIf="form.get('overheat_mode')?.value === 1" class="mt-4">
@@ -36,11 +60,11 @@
             <div class="col-1 md:col-10 md:flex-order-2">
                 <p-checkbox name="autofanspeed" formControlName="autofanspeed" inputId="autofanspeed" [binary]="true"></p-checkbox>
             </div>
-            <label htmlFor="autofanspeed" class="col-11 m-0 pl-3 md:col-2 md:flex-order-1 md:p-2">Automatic Fan Control</label>
+            <label for="autofanspeed" class="col-11 m-0 pl-3 md:col-2 md:flex-order-1 md:p-2">Automatic Fan Control</label>
         </div>
 
         <div *ngIf="form.controls['autofanspeed'].value" class="grid p-fluid my-2">
-            <label htmlFor="temptarget" class="hidden md:flex md:col-2 md:m-0">Target Temperature</label>
+            <label class="hidden md:flex md:col-2 md:m-0 hover-next-input">Target Temperature</label>
             <div class="col-12 md:col-10">
                 <label class="block mb-1">
                     <span class="md:hidden mr-1">Target Temperature:</span>{{form.controls['temptarget'].value}} °C
@@ -50,7 +74,7 @@
         </div>
 
         <div *ngIf="form.controls['autofanspeed'].value" class="grid p-fluid">
-            <label htmlFor="minfanspeed" class="hidden md:flex md:col-2 md:m-0">Minimum Fan Speed</label>
+            <label class="hidden md:flex md:col-2 md:m-0 hover-next-input">Minimum Fan Speed</label>
             <div class="col-12 md:col-10">
                 <label class="block mb-1">
                     <span class="md:hidden mr-1">Minimum Fan Speed:</span>{{form.controls['minfanspeed'].value}} %
@@ -60,7 +84,7 @@
         </div>
 
         <div *ngIf="!form.controls['autofanspeed'].value" class="grid p-fluid mt-2">
-            <label htmlFor="fanspeed" class="hidden md:flex md:col-2 md:m-0">Fan Speed</label>
+            <label class="hidden md:flex md:col-2 md:m-0 hover-next-input">Fan Speed</label>
             <div class="col-12 md:col-10">
                 <label class="block mb-1">
                     <span class="md:hidden mr-1">Fan Speed:</span>{{form.controls['fanspeed'].value}} %
@@ -80,21 +104,21 @@
 
     <div class="card">
         <div class="field grid p-fluid">
-            <label htmlFor="display" class="col-12 md:col-2 md:m-0">Type</label>
+            <label (click)="displayDropdown.show()" class="col-12 md:col-2 md:m-0 hover-next-input">Type</label>
             <div class="col-12 md:col-10">
-                <p-dropdown [options]="displays" formControlName="display"></p-dropdown>
+                <p-dropdown [options]="displays" formControlName="display" #displayDropdown></p-dropdown>
             </div>
         </div>
 
         <div class="field grid p-fluid">
-            <label htmlFor="rotation" class="col-12 md:col-2 md:m-0">Rotation</label>
+            <label (click)="rotationDropdown.show()" class="col-12 md:col-2 md:m-0 hover-next-input">Rotation</label>
             <div class="col-12 md:col-10">
-                <p-dropdown [options]="rotations" formControlName="rotation"></p-dropdown>
+                <p-dropdown [options]="rotations" formControlName="rotation" #rotationDropdown></p-dropdown>
             </div>
         </div>
 
         <div class="field grid p-fluid">
-            <label htmlFor="displayTimeoutControl" class="col-12 md:col-2 hidden md:flex md:m-0 relative">
+            <label class="col-12 md:col-2 hidden md:flex md:m-0 relative hover-next-input">
                 Sleep
             </label>
             <div class="col-12 md:col-10">
@@ -118,7 +142,7 @@
             <div class="col-1 md:col-10 md:flex-order-2">
                 <p-checkbox name="invertscreen" formControlName="invertscreen" inputId="invertscreen" [binary]="true"></p-checkbox>
             </div>
-            <label htmlFor="invertscreen" class="col-11 m-0 pl-3 md:col-2 md:flex-order-1 md:p-2">Invert Display Colors</label>
+            <label for="invertscreen" class="col-11 m-0 pl-3 md:col-2 md:flex-order-1 md:p-2">Invert Display Colors</label>
         </div>
     </div>
 
@@ -126,7 +150,7 @@
 
     <div class="card">
         <div class="grid p-fluid">
-            <label htmlFor="statsFrequencyControl" class="col-12 md:col-2 hidden md:flex md:m-0 relative">
+            <label class="col-12 md:col-2 hidden md:flex md:m-0 relative hover-next-input">
                 Data Logging
             </label>
             <div class="col-12 md:col-10">

--- a/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.html
+++ b/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.html
@@ -1,13 +1,13 @@
 <form *ngIf="form" [formGroup]="form">
     <div class="card">
         <div class="field grid p-fluid">
-            <label htmlFor="hostname" class="col-12 md:col-2 md:m-0">Hostname</label>
+            <label for="hostname" class="col-12 md:col-2 md:m-0">Hostname</label>
             <div class="col-12 md:col-10">
                 <input pInputText id="hostname" type="text" formControlName="hostname" />
             </div>
         </div>
         <div class="field grid p-fluid">
-            <label htmlFor="ssid" class="col-12 md:col-2 md:m-0">Wi-Fi SSID</label>
+            <label for="ssid" class="col-12 md:col-2 md:m-0">Wi-Fi SSID</label>
             <div class="col-12 md:col-10 p-inputgroup">
                 <input pInputText id="ssid" type="text" formControlName="ssid" />
                 <p-button
@@ -20,7 +20,7 @@
             </div>
         </div>
         <div class="field grid p-fluid">
-            <label htmlFor="wifiPass" class="col-12 md:col-2 md:m-0">Wi-Fi Password</label>
+            <label for="wifiPass" class="col-12 md:col-2 md:m-0">Wi-Fi Password</label>
             <div class="col-12 md:col-10 p-input-icon-right">
                 <i *ngIf="form.get('wifiPass')?.dirty" class="pi cursor-pointer"
                     [ngClass]="{'pi-eye': !showWifiPassword, 'pi-eye-slash': showWifiPassword}"

--- a/main/http_server/axe-os/src/app/layout/styles/theme/theme-base/_mixins.scss
+++ b/main/http_server/axe-os/src/app/layout/styles/theme/theme-base/_mixins.scss
@@ -19,7 +19,6 @@
 @mixin focused-input() {
     outline: $focusOutline;
     outline-offset: $inputFocusOutlineOffset;
-    box-shadow: $focusShadow;
 	border-color: $inputFocusBorderColor;
 }
 

--- a/main/http_server/axe-os/src/styles.scss
+++ b/main/http_server/axe-os/src/styles.scss
@@ -31,6 +31,21 @@ p-chart>div {
     }
 }
 
+.hover-next-input:hover + * {
+    .p-dropdown {
+        border-color: var(--checkbox-hover-bg);
+    }
+    .p-slider {
+        .p-slider-handle {
+            border-color: var(--checkbox-hover-bg);
+            background-color: var(--checkbox-hover-bg);
+        }
+        .p-slider-range {
+            background-color: var(--checkbox-hover-bg);
+        }
+    }
+}
+
 /* PrimeNG Component Theme Overrides */
 .p-slider {
     .p-slider-range {


### PR DESCRIPTION
As I mentioned in my [comment](https://github.com/bitaxeorg/ESP-Miner/issues/1194#issuecomment-3192507963), each [form label](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/label) should be linked to its corresponding form control (text field, checkbox, dropdown). This improves the user experience and accessibility.

This PR resolves issues with incorrect and missing associations between labels and input fields. The following tasks have been completed:

- [x] Set missing `for` attributes.
- [x] Add `click` handler to support `<p-dropdown>` because custom components can't be linked by `for` attribute.
- [x] Add `hover-next-input` CSS class to labels with custom components to unify the hover design.
- [x] Remove unnecessary `box-shadow` from `input:focus`

Closes https://github.com/bitaxeorg/ESP-Miner/issues/1194