### PR TITLE
Remove unused edit.component.scss

### DIFF
--- a/main/http_server/axe-os/src/app/components/edit/edit.component.scss
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.scss
@@ -1,5 +1,0 @@
-.pi {
-    right: 1rem;
-    font-size: 1.5rem;
-    top: 1rem;
-}

--- a/main/http_server/axe-os/src/app/components/edit/edit.component.ts
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.ts
@@ -17,8 +17,7 @@ const STATS_FREQUENCY_STEPS = [0, 30, 60, 60 * 2, 60 * 6, 60 * 14, 60 * 28, 60 *
 
 @Component({
   selector: 'app-edit',
-  templateUrl: './edit.component.html',
-  styleUrls: ['./edit.component.scss']
+  templateUrl: './edit.component.html'
 })
 
 export class EditComponent implements OnInit, OnDestroy, OnChanges {


### PR DESCRIPTION
Since the fields for Wi-Fi and Stratum password have their own views, the CSS definition for the `pi-eye` icon is no longer needed inside the `edit.component.scss`. Therefore, the SCSS file is also unnecessary, as it would be empty.

Related commit where `edit.component.scss` was added: https://github.com/bitaxeorg/ESP-Miner/commit/91e4e5f3aae14b71a5b3355e23530690a814dd69