### PR TITLE
Destroy subscriptions when leaving page

### DIFF
--- a/main/http_server/axe-os/src/app/components/system/system.component.ts
+++ b/main/http_server/axe-os/src/app/components/system/system.component.ts
@@ -36,11 +36,11 @@ export class SystemComponent implements OnInit, OnDestroy {
   ) {
     this.info$ = timer(0, 5000).pipe(
       switchMap(() => this.systemService.getInfo()),
-      shareReplay(1)
+      shareReplay({ refCount: true, bufferSize: 1 })
     );
 
     this.asic$ = this.systemService.getAsicSettings().pipe(
-      shareReplay(1)
+      shareReplay({ refCount: true, bufferSize: 1 })
     );
 
     this.combinedData$ = combineLatest([this.info$, this.asic$]).pipe(

--- a/main/http_server/axe-os/src/app/components/update/update.component.ts
+++ b/main/http_server/axe-os/src/app/components/update/update.component.ts
@@ -45,7 +45,7 @@ export class UpdateComponent {
     this.info$ = timer(0, 5000).pipe(
       switchMap(() => this.systemService.getInfo()),
       distinctUntilChanged((prev, curr) => JSON.stringify(prev) === JSON.stringify(curr)),
-      shareReplay(1)
+      shareReplay({ refCount: true, bufferSize: 1 })
     );
   }
 


### PR DESCRIPTION
Some pages didn't destroy subscriptions when switching to another page. On returning to the page, a new subscription was added, accumulating more and more. Fixed by setting `refCount: true` on `shareReplay`.