### PR TITLE
Option to disable suggested difficulty

### DIFF
--- a/main/http_server/axe-os/src/app/components/pool/pool.component.html
+++ b/main/http_server/axe-os/src/app/components/pool/pool.component.html
@@ -48,7 +48,7 @@
                         <label [htmlFor]="pool + 'SuggestedDifficulty'" class="col-12 md:col-2 md:mb-0">
                             Suggested <span class="white-space-nowrap">
                                 Difficulty
-                                <i class="pi pi-info-circle text-xs px-1" pTooltip="Used to indicate a preference for share difficulty to the pool. Servers are not required to honour this request, even if they support the stratum method."></i>
+                                <i class="pi pi-info-circle text-xs px-1" pTooltip="Used to indicate a preference for share difficulty to the pool. Servers are not required to honour this request, even if they support the stratum method. (0 to disable)"></i>
                             </span>
                         </label>
                         <div class="col-12 md:col-10">

--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -494,7 +494,7 @@ void stratum_task(void * pvParameters)
                 retry_attempts = 0;
                 if (stratum_api_v1_message.response_success) {
                     ESP_LOGI(TAG, "setup message accepted");
-                    if (stratum_api_v1_message.message_id == authorize_message_id) {
+                    if (stratum_api_v1_message.message_id == authorize_message_id && difficulty > 0) {
                         STRATUM_V1_suggest_difficulty(GLOBAL_STATE->sock, GLOBAL_STATE->send_uid++, difficulty);
                     }
                     if (extranonce_subscribe) {


### PR DESCRIPTION
Setting it to 0 will not send the `mining.suggest_difficulty` and let the pool decide on difficulty.