### PR TITLE
Fix swarm live data with fallback fields

### DIFF
--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -169,7 +169,7 @@ export class SwarmComponent implements OnInit, OnDestroy {
       }).pipe(
         map(({ info, asic }) => {
           const existingDevice = this.swarm.find(device => device.IP === IP);
-          return this.fallbackDeviceModel({ IP, ...(existingDevice ? existingDevice : {}), ...info, ...asic });
+          return this.fallbackDeviceModel({ IP, ...(existingDevice ? existingDevice : {}), ...info, ...asic, ...this.numerizeDeviceBestDiffs(info) });
         }),
         timeout(5000),
         catchError(error => errorHandler(error, IP))
@@ -196,7 +196,7 @@ export class SwarmComponent implements OnInit, OnDestroy {
       if (!info.ASICModel || !asic.ASICModel) {
         return;
       }
-      this.swarm.push(this.fallbackDeviceModel({ IP, ...info, ...asic }));
+      this.swarm.push(this.fallbackDeviceModel({ IP, ...info, ...asic, ...this.numerizeDeviceBestDiffs(info) }));
       this.sortSwarm();
       this.localStorageService.setObject(SWARM_DATA, this.swarm);
       this.calculateTotals();


### PR DESCRIPTION
Small fix to also look for fallback fields on live swarm data. Also added `hashRate_10m` fallback for old AxeOS versions.