### PR TITLE
Fix watchdog timer on screen init

### DIFF
--- a/main/screen.c
+++ b/main/screen.c
@@ -590,36 +590,39 @@ static void uptime_update_cb(lv_timer_t * timer)
 
 esp_err_t screen_start(void * pvParameters)
 {
-    // screen_chars = lv_display_get_horizontal_resolution(NULL) / 6;
-    screen_lines = lv_display_get_vertical_resolution(NULL) / 8;
+    if (lvgl_port_lock(0)) {
+        // screen_chars = lv_display_get_horizontal_resolution(NULL) / 6;
+        screen_lines = lv_display_get_vertical_resolution(NULL) / 8;
 
-    GLOBAL_STATE = (GlobalState *) pvParameters;
+        GLOBAL_STATE = (GlobalState *) pvParameters;
 
-    if (GLOBAL_STATE->SYSTEM_MODULE.is_screen_active) {
-        SystemModule * module = &GLOBAL_STATE->SYSTEM_MODULE;
+        if (GLOBAL_STATE->SYSTEM_MODULE.is_screen_active) {
+            SystemModule * module = &GLOBAL_STATE->SYSTEM_MODULE;
 
-        screens[SCR_SELF_TEST] = create_scr_self_test();
-        screens[SCR_OVERHEAT] = create_scr_overheat(module);
-        screens[SCR_ASIC_STATUS] = create_scr_asic_status(module);
-        screens[SCR_WELCOME] = create_scr_welcome(module);
-        screens[SCR_FIRMWARE] = create_scr_firmware(module);
-        screens[SCR_CONNECTION] = create_scr_connection(module);
-        screens[SCR_BITAXE_LOGO] = create_scr_bitaxe_logo(GLOBAL_STATE->DEVICE_CONFIG.family.name, GLOBAL_STATE->DEVICE_CONFIG.board_version);
-        screens[SCR_OSMU_LOGO] = create_scr_osmu_logo();
-        screens[SCR_URLS] = create_scr_urls(module);
-        screens[SCR_STATS] = create_scr_stats();
-        screens[SCR_MINING] = create_scr_mining();
-        screens[SCR_WIFI] = create_scr_wifi();
+            screens[SCR_SELF_TEST] = create_scr_self_test();
+            screens[SCR_OVERHEAT] = create_scr_overheat(module);
+            screens[SCR_ASIC_STATUS] = create_scr_asic_status(module);
+            screens[SCR_WELCOME] = create_scr_welcome(module);
+            screens[SCR_FIRMWARE] = create_scr_firmware(module);
+            screens[SCR_CONNECTION] = create_scr_connection(module);
+            screens[SCR_BITAXE_LOGO] = create_scr_bitaxe_logo(GLOBAL_STATE->DEVICE_CONFIG.family.name, GLOBAL_STATE->DEVICE_CONFIG.board_version);
+            screens[SCR_OSMU_LOGO] = create_scr_osmu_logo();
+            screens[SCR_URLS] = create_scr_urls(module);
+            screens[SCR_STATS] = create_scr_stats();
+            screens[SCR_MINING] = create_scr_mining();
+            screens[SCR_WIFI] = create_scr_wifi();
 
-        notification_label = lv_label_create(lv_layer_top());
-        lv_label_set_text(notification_label, "");
-        lv_obj_align(notification_label, LV_ALIGN_TOP_RIGHT, 0, 0);
-        lv_obj_add_flag(notification_label, LV_OBJ_FLAG_HIDDEN);
+            notification_label = lv_label_create(lv_layer_top());
+            lv_label_set_text(notification_label, "");
+            lv_obj_align(notification_label, LV_ALIGN_TOP_RIGHT, 0, 0);
+            lv_obj_add_flag(notification_label, LV_OBJ_FLAG_HIDDEN);
 
-        lv_timer_create(screen_update_cb, SCREEN_UPDATE_MS, NULL);
+            lv_timer_create(screen_update_cb, SCREEN_UPDATE_MS, NULL);
 
-        // Create uptime update timer (runs every 1 second)
-        lv_timer_create(uptime_update_cb, 1000, NULL);
+            // Create uptime update timer (runs every 1 second)
+            lv_timer_create(uptime_update_cb, 1000, NULL);
+        }
+        lvgl_port_unlock();
     }
 
     return ESP_OK;


### PR DESCRIPTION
On some boots, the watchdog is triggered while initialising the LVGL layout:
```
I (5869) connect: Configuration Access Point disabled
I (7127) connect: IPv6 Address: FE80::4A27:E2FF:FEEF:9B6C
E (7399) task_wdt: Task watchdog got triggered. The following tasks/users did not reset the watchdog in time:
E (7399) task_wdt:  - IDLE0 (CPU 0)
E (7399) task_wdt: Tasks currently running:
E (7399) task_wdt: CPU 0: main
E (7399) task_wdt: CPU 1: IDLE1
E (7399) task_wdt: Print CPU 0 (current core) backtrace


Backtrace: 0x4204C0DB:0x3FC9EEC0 0x40377309:0x3FC9EEF0 0x4202D029:0x3FCBF8E0 0x4202887A:0x3FCBF920 0x420288C5:0x3FCBF950 0x42027ED2:0x3FCBF980 0x4202AE38:0x3FCBF9B0 0x4202B4B3:0x3FCBF9F0 0x420275C3:0x3FCBFA10 0x4203C5CF:0x3FCBFA30 0x42018136:0x3FCBFA50 0x4200E915:0x3FCBFA70 0x4200E413:0x3FCBFAA0 0x420DFA57:0x3FCBFAD0
--- 0x4204c0db: task_wdt_timeout_handling at /home/mutatrum/esp/v5.5.1/esp-idf/components/esp_system/task_wdt/task_wdt.c:436
--- (inlined by) task_wdt_isr at /home/mutatrum/esp/v5.5.1/esp-idf/components/esp_system/task_wdt/task_wdt.c:509
--- 0x40377309: _xt_lowint1 at /home/mutatrum/esp/v5.5.1/esp-idf/components/xtensa/xtensa_vectors.S:1240
--- 0x4202d029: lv_inv_area at /home/mutatrum/code-workspace/esp-miner/managed_components/lvgl__lvgl/src/core/lv_refr.c:277
--- 0x4202887a: lv_obj_invalidate_area at /home/mutatrum/code-workspace/esp-miner/managed_components/lvgl__lvgl/src/core/lv_obj_pos.c:847
...
--- 0x4203c5cf: lv_label_create at /home/mutatrum/code-workspace/esp-miner/managed_components/lvgl__lvgl/src/widgets/label/lv_label.c:125
--- 0x42018136: screen_start at /home/mutatrum/code-workspace/esp-miner/main/screen.c:614
--- 0x4200e915: SYSTEM_init_peripherals at /home/mutatrum/code-workspace/esp-miner/main/system.c:124
--- 0x4200e413: app_main at /home/mutatrum/code-workspace/esp-miner/main/main.c:69
--- 0x420dfa57: main_task at /home/mutatrum/esp/v5.5.1/esp-idf/components/freertos/app_startup.c:208
```
My suspicion is that it's a deadlock due to it not being guarded by the LVGL lock.