### PR TITLE
Fix scriptsig decoder crash

### DIFF
--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -268,7 +268,7 @@ void decode_mining_notification(GlobalState * GLOBAL_STATE, const mining_notify 
         GLOBAL_STATE->block_height = block_height;
     }
 
-    size_t scriptsig_length = scriptsig_len - 1 - block_height_len;;
+    size_t scriptsig_length = scriptsig_len - 1 - block_height_len;
     if (coinbase_1_len - coinbase_1_offset < scriptsig_len - 1 - block_height_len) {
         scriptsig_length -= (strlen(GLOBAL_STATE->extranonce_str) / 2) + GLOBAL_STATE->extranonce_2_len;
     }


### PR DESCRIPTION
Fixes #1272.

Decoder crashed because scriptsig was completely in `coinbase_1`, and deducting the length of `extranonce` and `extranonce_2` made it access out of bounds memory.