### PR TITLE
fixes missing zone identifier append

### DIFF
--- a/main/global_state.h
+++ b/main/global_state.h
@@ -48,7 +48,7 @@ typedef struct
     char ssid[32];
     char wifi_status[256];
     char ip_addr_str[16]; // IP4ADDR_STRLEN_MAX
-    char ipv6_addr_str[40]; // IPv6 address string
+    char ipv6_addr_str[64]; // IPv6 address string with zone identifier (INET6_ADDRSTRLEN=46 + % + interface=15)
     char ap_ssid[32];
     bool ap_enabled;
     bool is_connected;


### PR DESCRIPTION
ipv6 zone identifiers were missing on link local addresses. Being appended now and added comments for clarity. Don't touch this code again!