### PR TITLE
Improving sensitive data masking for text fields

### DIFF
--- a/main/http_server/axe-os/src/app/layout/styles/layout/_utils.scss
+++ b/main/http_server/axe-os/src/app/layout/styles/layout/_utils.scss
@@ -29,10 +29,9 @@
 
 .sensitive-data-hidden {
     [sensitive-data] {
-        font-size: 0;
-
         &.p-inputtext {
-            height: 2.536rem;
+            -webkit-text-security: disc;
+            pointer-events: none;
         }
 
         &::before {


### PR DESCRIPTION
A small adjustment for better appearance of masked input fields when privacy mode (sensitive data) is on.

* The content of the input field is no longer hidden; now it masked with dots (like a password field).
* The input field cannot be edited.


https://github.com/user-attachments/assets/e155893a-feee-4862-afe1-9672eadf6391

