### PR TITLE
Fix JSON of DEFAULT_COLORS

### DIFF
--- a/main/http_server/theme_api.c
+++ b/main/http_server/theme_api.c
@@ -40,31 +40,6 @@ static esp_err_t theme_get_handler(httpd_req_t *req)
     cJSON *colors_json = cJSON_Parse(colors);
     if (colors_json) {
         cJSON_AddItemToObject(root, "accentColors", colors_json);
-    } else {
-        // If no colors are stored, return default red theme colors
-        cJSON *default_colors = cJSON_CreateObject();
-        cJSON_AddStringToObject(default_colors, "--primary-color", "#F80421");
-        cJSON_AddStringToObject(default_colors, "--primary-color-text", "#ffffff");
-        cJSON_AddStringToObject(default_colors, "--highlight-bg", "#F80421");
-        cJSON_AddStringToObject(default_colors, "--highlight-text-color", "#ffffff");
-        cJSON_AddStringToObject(default_colors, "--focus-ring", "0 0 0 0.2rem rgba(248,4,33,0.2)");
-        cJSON_AddStringToObject(default_colors, "--slider-bg", "#dee2e6");
-        cJSON_AddStringToObject(default_colors, "--slider-range-bg", "#F80421");
-        cJSON_AddStringToObject(default_colors, "--slider-handle-bg", "#F80421");
-        cJSON_AddStringToObject(default_colors, "--progressbar-bg", "#dee2e6");
-        cJSON_AddStringToObject(default_colors, "--progressbar-value-bg", "#F80421");
-        cJSON_AddStringToObject(default_colors, "--checkbox-border", "#F80421");
-        cJSON_AddStringToObject(default_colors, "--checkbox-bg", "#F80421");
-        cJSON_AddStringToObject(default_colors, "--checkbox-hover-bg", "#df031d");
-        cJSON_AddStringToObject(default_colors, "--button-bg", "#F80421");
-        cJSON_AddStringToObject(default_colors, "--button-hover-bg", "#df031d");
-        cJSON_AddStringToObject(default_colors, "--button-focus-shadow", "0 0 0 2px #ffffff, 0 0 0 4px #F80421");
-        cJSON_AddStringToObject(default_colors, "--togglebutton-bg", "#F80421");
-        cJSON_AddStringToObject(default_colors, "--togglebutton-border", "1px solid #F80421");
-        cJSON_AddStringToObject(default_colors, "--togglebutton-hover-bg", "#df031d");
-        cJSON_AddStringToObject(default_colors, "--togglebutton-hover-border", "1px solid #df031d");
-        cJSON_AddStringToObject(default_colors, "--togglebutton-text-color", "#ffffff");
-        cJSON_AddItemToObject(root, "accentColors", default_colors);
     }
 
     esp_err_t res = HTTP_send_json(req, root, &theme_prebuffer_len);

--- a/main/http_server/theme_api.h
+++ b/main/http_server/theme_api.h
@@ -5,27 +5,27 @@
 
 #define DEFAULT_THEME "dark"
 #define DEFAULT_COLORS "{ "\
-        "--primary-color\":\"#F80421\", "\
-        "--primary-color-text\":\"#ffffff\", "\
-        "--highlight-bg\":\"#F80421\", "\
-        "--highlight-text-color\":\"#ffffff\", "\
-        "--focus-ring\":\"0 0 0 0.2rem rgba(248,4,33,0.2)\", "\
-        "--slider-bg\":\"#dee2e6\", "\
-        "--slider-range-bg\":\"#F80421\", "\
-        "--slider-handle-bg\":\"#F80421\", "\
-        "--progressbar-bg\":\"#dee2e6\", "\
-        "--progressbar-value-bg\":\"#F80421\", "\
-        "--checkbox-border\":\"#F80421\", "\
-        "--checkbox-bg\":\"#F80421\", "\
-        "--checkbox-hover-bg\":\"#df031d\", "\
-        "--button-bg\":\"#F80421\", "\
-        "--button-hover-bg\":\"#df031d\", "\
-        "--button-focus-shadow\":\"0 0 0 2px #ffffff, 0 0 0 4px #F80421\", "\
-        "--togglebutton-bg\":\"#F80421\", "\
-        "--togglebutton-border\":\"1px solid #F80421\", "\
-        "--togglebutton-hover-bg\":\"#df031d\", "\
-        "--togglebutton-hover-border\":\"1px solid #df031d\", "\
-        "--togglebutton-text-color\":\"#ffffff\" "\
+        "\"--primary-color\":\"#F80421\", "\
+        "\"--primary-color-text\":\"#ffffff\", "\
+        "\"--highlight-bg\":\"#F80421\", "\
+        "\"--highlight-text-color\":\"#ffffff\", "\
+        "\"--focus-ring\":\"0 0 0 0.2rem rgba(248,4,33,0.2)\", "\
+        "\"--slider-bg\":\"#dee2e6\", "\
+        "\"--slider-range-bg\":\"#F80421\", "\
+        "\"--slider-handle-bg\":\"#F80421\", "\
+        "\"--progressbar-bg\":\"#dee2e6\", "\
+        "\"--progressbar-value-bg\":\"#F80421\", "\
+        "\"--checkbox-border\":\"#F80421\", "\
+        "\"--checkbox-bg\":\"#F80421\", "\
+        "\"--checkbox-hover-bg\":\"#df031d\", "\
+        "\"--button-bg\":\"#F80421\", "\
+        "\"--button-hover-bg\":\"#df031d\", "\
+        "\"--button-focus-shadow\":\"0 0 0 2px #ffffff, 0 0 0 4px #F80421\", "\
+        "\"--togglebutton-bg\":\"#F80421\", "\
+        "\"--togglebutton-border\":\"1px solid #F80421\", "\
+        "\"--togglebutton-hover-bg\":\"#df031d\", "\
+        "\"--togglebutton-hover-border\":\"1px solid #df031d\", "\
+        "\"--togglebutton-text-color\":\"#ffffff\" "\
         "}"
 
 // Register theme API endpoints


### PR DESCRIPTION
Follow-up of #1295. The problem was that the JSON of the `DEFAULT_COLORS` define was not properly formatted.

However, there's a pending issue that on initial load, the theme page doesn't select the current color scheme. On page reload of the theme page, it does work.

So, opening the dashboard, navigating to theme. The chosen theme (green) is applied, but there's no checkmark there:

<img width="1969" height="759" alt="image" src="https://github.com/user-attachments/assets/b7c554bb-74e1-49af-8857-9282848d9b51" />

This was the case before 1295, with 1295 and with this fix.