### PR TITLE
Mobile: Moving quick links from the menu to the top bar

### DIFF
--- a/main/http_server/axe-os/src/app/layout/app.menu.component.html
+++ b/main/http_server/axe-os/src/app/layout/app.menu.component.html
@@ -1,23 +1,3 @@
-<ng-container *ngIf="isMobile()">
-    <ul *ngIf="info$ | async as info" class="flex lg:hidden list-none absolute flex p-0 mt-0 mr-4 mt-3 gap-4 right-0 top-0">
-        <li>
-            <a class="block text-white" (click)="toggleSensitiveData()">
-                <i class="pi pi-{{sensitiveDataHidden ? 'eye-slash' : 'eye'}} block" style="font-size: 1.4rem;"></i>
-            </a>
-        </li>
-        <li>
-            <a routerLink="network" class="block">
-                <wifi-icon [rssi]="info.wifiRSSI" />
-            </a>
-        </li>
-        <li>
-            <a class="block text-white" (click)="restart()">
-                <i class="pi pi-refresh text-xl block"></i>
-            </a>
-        </li>
-    </ul>
-</ng-container>
-
 <ul class="layout-menu">
     <ng-container *ngFor="let item of model; let i = index;">
         <li app-menuitem *ngIf="!item.separator" [item]="item" [index]="i" [root]="true"></li>

--- a/main/http_server/axe-os/src/app/layout/app.menu.component.ts
+++ b/main/http_server/axe-os/src/app/layout/app.menu.component.ts
@@ -1,76 +1,45 @@
 import { Component, OnInit } from '@angular/core';
-import { Observable, shareReplay, Subject, takeUntil } from 'rxjs';
-import { ToastrService } from 'ngx-toastr';
+import { Observable, shareReplay } from 'rxjs';
 import { SystemService } from '../services/system.service';
 import { LayoutService } from './service/app.layout.service';
-import { SensitiveData } from 'src/app/services/sensitive-data.service';
 import { ISystemInfo } from 'src/models/ISystemInfo';
 
 @Component({
-    selector: 'app-menu',
-    templateUrl: './app.menu.component.html'
+  selector: 'app-menu',
+  templateUrl: './app.menu.component.html'
 })
 export class AppMenuComponent implements OnInit {
-    private destroy$ = new Subject<void>();
+  public info$!: Observable<ISystemInfo>;
 
-    public sensitiveDataHidden: boolean = false;
-    public info$!: Observable<ISystemInfo>;
+  model: any[] = [];
 
-    model: any[] = [];
+  constructor(public layoutService: LayoutService,
+    private systemService: SystemService,
+  ) {
+    this.info$ = this.systemService.getInfo().pipe(shareReplay({ refCount: true, bufferSize: 1 }))
+  }
 
-    constructor(public layoutService: LayoutService,
-        private systemService: SystemService,
-        private toastr: ToastrService,
-        private sensitiveData: SensitiveData,
-    ) {
-        this.info$ = this.systemService.getInfo().pipe(shareReplay({refCount: true, bufferSize: 1}))
-    }
+  ngOnInit() {
+    this.model = [
+      {
+        label: 'Menu',
+        items: [
+          { label: 'Dashboard', icon: 'pi pi-fw pi-home', routerLink: ['/'] },
+          { label: 'Swarm', icon: 'pi pi-fw pi-sitemap', routerLink: ['swarm'] },
+          { label: 'Logs', icon: 'pi pi-fw pi-list', routerLink: ['logs'] },
+          { label: 'System', icon: 'pi pi-fw pi-wave-pulse', routerLink: ['system'] },
+          { separator: true },
 
-    ngOnInit() {
-        this.model = [
-            {
-                label: 'Menu',
-                items: [
-                    { label: 'Dashboard', icon: 'pi pi-fw pi-home', routerLink: ['/'] },
-                    { label: 'Swarm', icon: 'pi pi-fw pi-sitemap', routerLink: ['swarm'] },
-                    { label: 'Logs', icon: 'pi pi-fw pi-list', routerLink: ['logs'] },
-                    { label: 'System', icon: 'pi pi-fw pi-wave-pulse', routerLink: ['system'] },
-                    { separator: true },
+          { label: 'Pool', icon: 'pi pi-fw pi-server', routerLink: ['pool'] },
+          { label: 'Network', icon: 'pi pi-fw pi-wifi', routerLink: ['network'] },
+          { label: 'Theme', icon: 'pi pi-fw pi-palette', routerLink: ['design'] },
+          { label: 'Settings', icon: 'pi pi-fw pi-cog', routerLink: ['settings'] },
+          { label: 'Update', icon: 'pi pi-fw pi-sync', routerLink: ['update'] },
+          { separator: true },
 
-                    { label: 'Pool', icon: 'pi pi-fw pi-server', routerLink: ['pool'] },
-                    { label: 'Network', icon: 'pi pi-fw pi-wifi', routerLink: ['network'] },
-                    { label: 'Theme', icon: 'pi pi-fw pi-palette', routerLink: ['design'] },
-                    { label: 'Settings', icon: 'pi pi-fw pi-cog', routerLink: ['settings'] },
-                    { label: 'Update', icon: 'pi pi-fw pi-sync', routerLink: ['update'] },
-                    { separator: true },
-
-                    { label: 'Whitepaper', icon: 'pi pi-fw pi-bitcoin', command: () => window.open('/bitcoin.pdf', '_blank') },
-                ]
-            }
-        ];
-
-        this.sensitiveData.hidden
-          .pipe(takeUntil(this.destroy$))
-          .subscribe((hidden: boolean) => {
-            this.sensitiveDataHidden = hidden;
-          });
-    }
-
-    ngOnDestroy() {
-      this.destroy$.next();
-      this.destroy$.complete();
-    }
-
-    public toggleSensitiveData() {
-      this.sensitiveData.toggle();
-    }
-
-    public restart() {
-        this.systemService.restart().subscribe(res => {});
-        this.toastr.success('Device restarted');
-    }
-
-    public isMobile() {
-        return !window.matchMedia("(min-width: 991px)").matches;
-    }
+          { label: 'Whitepaper', icon: 'pi pi-fw pi-bitcoin', command: () => window.open('/bitcoin.pdf', '_blank') },
+        ]
+      }
+    ];
+  }
 }

--- a/main/http_server/axe-os/src/app/layout/app.menuitem.component.ts
+++ b/main/http_server/axe-os/src/app/layout/app.menuitem.component.ts
@@ -11,7 +11,6 @@ import { LayoutService } from './service/app.layout.service';
     selector: '[app-menuitem]',
     template: `
 		<ng-container>
-            <div *ngIf="root && item.visible !== false" class="layout-menuitem-root-text">{{item.label}}</div>
 			<a *ngIf="(!item.routerLink || item.items) && item.visible !== false && !item.separator" [attr.href]="item.url" (click)="itemClick($event)"
 			   [ngClass]="item.class" [attr.target]="item.target" tabindex="0" pRipple>
 				<i [ngClass]="item.icon" class="layout-menuitem-icon"></i>

--- a/main/http_server/axe-os/src/app/layout/app.topbar.component.html
+++ b/main/http_server/axe-os/src/app/layout/app.topbar.component.html
@@ -12,17 +12,13 @@
         </svg>
     </a>
 
-    <button *ngIf="!isAPMode" #menubutton class="p-link layout-topbar-button" (click)="layoutService.onMenuToggle()">
-        <i class="pi pi-bars"></i>
-    </button>
-
     <ng-container *ngIf="info$ | async as info">
         <span class="text-500 select-none absolute left-0 bottom-0 ml-6 md:ml-7 mb-1"
             tooltipPosition="bottom"
             pTooltip="Hostname"
         >{{info.hostname}}</span>
 
-        <ul *ngIf="isDesktop()" class="hidden lg:flex ml-auto list-none p-0 gap-4">
+        <ul *ngIf="!isAPMode" class="flex ml-auto list-none p-0 m-0 gap-4 lg:flex-order-2">
             <li>
                 <a class="block py-2 text-white cursor-pointer"
                     tooltipPosition="bottom"
@@ -52,4 +48,9 @@
             </li>
         </ul>
     </ng-container>
+
+    <button *ngIf="!isAPMode" #menubutton class="p-link layout-topbar-button"
+        (click)="layoutService.onMenuToggle()">
+        <i class="pi pi-bars"></i>
+    </button>
 </div>

--- a/main/http_server/axe-os/src/app/layout/app.topbar.component.ts
+++ b/main/http_server/axe-os/src/app/layout/app.topbar.component.ts
@@ -54,8 +54,4 @@ export class AppTopBarComponent implements OnInit, OnDestroy {
       error: () => this.toastr.error('Restart failed')
     });
   }
-
-  public isDesktop() {
-    return window.matchMedia("(min-width: 991px)").matches;
-  }
 }

--- a/main/http_server/axe-os/src/app/layout/styles/layout/_menu.scss
+++ b/main/http_server/axe-os/src/app/layout/styles/layout/_menu.scss
@@ -1,6 +1,5 @@
 .layout-sidebar {
     position: fixed;
-    width: var(--sidebar-width);
     height: calc(100vh - 9.5rem);
     z-index: 999;
     overflow-y: auto;
@@ -10,8 +9,12 @@
     transition: transform $transitionDuration, left $transitionDuration;
     background-color: var(--surface-overlay);
     border-radius: $borderRadius;
-    padding: 0.5rem 1.5rem;
+    padding: 1.5rem;
     box-shadow: 0px 3px 5px rgba(0, 0, 0, .02), 0px 0px 2px rgba(0, 0, 0, .05), 0px 1px 4px rgba(0, 0, 0, .08);
+
+    @media screen and (min-width: 992px) {
+        width: var(--sidebar-width);
+    }
 }
 
 .layout-menu {

--- a/main/http_server/axe-os/src/app/layout/styles/layout/_topbar.scss
+++ b/main/http_server/axe-os/src/app/layout/styles/layout/_topbar.scss
@@ -10,7 +10,10 @@
     transition: left $transitionDuration;
     display: flex;
     align-items: center;
-    box-shadow: 0px 3px 5px rgba(0,0,0,.02), 0px 0px 2px rgba(0,0,0,.05), 0px 1px 4px rgba(0,0,0,.08);
+    box-shadow:
+        0px 3px 5px rgba(0, 0, 0, 0.02),
+        0px 0px 2px rgba(0, 0, 0, 0.05),
+        0px 1px 4px rgba(0, 0, 0, 0.08);
 
     @media screen and (max-width: 575px) {
         justify-content: space-between;
@@ -29,10 +32,13 @@
         width: 3rem;
         height: 3rem;
         cursor: pointer;
-        transition: background-color color $transitionDuration;
+        transition:
+            background-color $transitionDuration,
+            color $transitionDuration;
+        margin-left: 2rem;
 
         @media screen and (min-width: 576px) {
-            margin-left: 6rem;
+            margin-left: 5rem;
         }
 
         &:hover {

--- a/main/http_server/axe-os/src/app/layout/styles/theme/themes/vela/_variables.scss
+++ b/main/http_server/axe-os/src/app/layout/styles/theme/themes/vela/_variables.scss
@@ -951,7 +951,7 @@ $imagePreviewActionIconBorderRadius: 50% !default;
     --highlight-bg: #{$highlightBg};
     --highlight-text-color: #{$highlightTextColor};
     --focus-ring: #{$focusShadow};
-    --sidebar-width: 180px;
+    --sidebar-width: 12rem;
     --topbar-height: 5.5rem;
     color-scheme: light dark;
 }


### PR DESCRIPTION
Currently, the quick links _Privacy Mode_, _Wi-Fi_, _Reboot_ are hidden in the mobile menu and can only be used when the menu is open. This PR moves the icons to the header, as in the desktop view, making them accessible at all times. 

**Before**
<img width="406" height="494" alt="Before" src="https://github.com/user-attachments/assets/92d8d32b-40d0-4177-a878-aa625e507f46" />

**After**
<img width="431" height="742" alt="After" src="https://github.com/user-attachments/assets/d83b2a55-c6f8-4589-b179-34f62020a2dd" />
