### PR TITLE
Remove spacing from suffixString

### DIFF
--- a/components/stratum/utils.c
+++ b/components/stratum/utils.c
@@ -318,14 +318,14 @@ void suffixString(uint64_t val, char * buf, size_t bufsiz, int sigdigits)
 
     if (!sigdigits) {
         if (decimal)
-            snprintf(buf, bufsiz, "%.2f %s", dval, suffix);
+            snprintf(buf, bufsiz, "%.2f%s", dval, suffix);
         else
-            snprintf(buf, bufsiz, "%d %s", (unsigned int) dval, suffix);
+            snprintf(buf, bufsiz, "%d%s", (unsigned int) dval, suffix);
     } else {
         /* Always show sigdigits + 1, padded on right with zeroes
          * followed by suffix */
         int ndigits = sigdigits - 1 - (dval > 0.0 ? floor(log10(dval)) : 0);
 
-        snprintf(buf, bufsiz, "%*.*f %s", sigdigits + 1, ndigits, dval, suffix);
+        snprintf(buf, bufsiz, "%*.*f%s", sigdigits + 1, ndigits, dval, suffix);
     }
 }

--- a/main/screen.c
+++ b/main/screen.c
@@ -462,7 +462,7 @@ static void screen_update_cb(lv_timer_t * timer)
 
     if (current_chip_temp != power_management->chip_temp_avg) {
         if (power_management->chip_temp_avg > 0) {
-            lv_label_set_text_fmt(stats_temp_label, "Temp: %.1f °C", power_management->chip_temp_avg);    
+            lv_label_set_text_fmt(stats_temp_label, "Temp: %.1f°C", power_management->chip_temp_avg);    
         }
         current_chip_temp = power_management->chip_temp_avg;
     }


### PR DESCRIPTION
This PR removes spaces from suffixString so that the string fits within the display width.

Fixes #1226 