### PR TITLE
Fix: Convert API networkDifficulty to number

### DIFF
--- a/main/global_state.h
+++ b/main/global_state.h
@@ -121,6 +121,7 @@ typedef struct
 
     int block_height;
     char * scriptsig;
+    uint64_t network_nonce_diff;
     char network_diff_string[DIFF_STRING_SIZE];
 } GlobalState;
 

--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -382,8 +382,8 @@
                     <div class="col-fixed-width text-500">
                         <span>Difficulty</span>
                     </div>
-                    <div>
-                        {{ info.networkDifficulty }}
+                    <div *ngIf="info.networkDifficulty">
+                        {{ info.networkDifficulty | diffSuffix }}
                     </div>
                 </div>
 

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -94,7 +94,7 @@ export class SystemService {
 
         blockHeight: 811111,
         scriptsig: "..%..h..,H...ckpool.eu/solo.ckpool.org/",
-        networkDifficulty: "25.3T",
+        networkDifficulty: 155970000000000,
         hashrateMonitor: {
           asics: [{
             total: 441.2579,

--- a/main/http_server/axe-os/src/models/ISystemInfo.ts
+++ b/main/http_server/axe-os/src/models/ISystemInfo.ts
@@ -84,7 +84,7 @@ export interface ISystemInfo {
 
     blockHeight?: number,
     scriptsig?: string,
-    networkDifficulty?: string,
+    networkDifficulty?: number,
 
     hashrateMonitor: IHashrateMonitor,
     blockFound: number,

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -837,7 +837,7 @@ static esp_err_t GET_system_info(httpd_req_t * req)
     if (GLOBAL_STATE->block_height > 0) {
         cJSON_AddNumberToObject(root, "blockHeight", GLOBAL_STATE->block_height);
         cJSON_AddStringToObject(root, "scriptsig", GLOBAL_STATE->scriptsig);
-        cJSON_AddStringToObject(root, "networkDifficulty", GLOBAL_STATE->network_diff_string);
+        cJSON_AddNumberToObject(root, "networkDifficulty", GLOBAL_STATE->network_nonce_diff);
     }
 
     cJSON *hashrate_monitor = cJSON_CreateObject();

--- a/main/http_server/openapi.yaml
+++ b/main/http_server/openapi.yaml
@@ -346,8 +346,8 @@ components:
           type: string
           description: Scriptsig extracted from coinbase transaction
         networkDifficulty:
-          type: string
-          description: Current network difficulty in human-readable format
+          type: number
+          description: Current network difficulty
         blockFound:
           type: number
           description: Whether a block was found (0=no, 1=yes)

--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -270,6 +270,7 @@ void stratum_primary_heartbeat(void * pvParameters)
 static void decode_mining_notification(GlobalState * GLOBAL_STATE, const mining_notify *mining_notification)
 {
     double network_difficulty = networkDifficulty(mining_notification->target);
+    GLOBAL_STATE->network_nonce_diff = (uint64_t) network_difficulty;
     suffixString(network_difficulty, GLOBAL_STATE->network_diff_string, DIFF_STRING_SIZE, 0);    
 
     int coinbase_1_len = strlen(mining_notification->coinbase_1) / 2;


### PR DESCRIPTION
Follow up PR for https://github.com/bitaxeorg/ESP-Miner/pull/1308

This PR converts `networkDifficulty` from a string to a number so that formatting takes place in AxeOS.

<img width="490" height="226" alt="Screenshot" src="https://github.com/user-attachments/assets/4afac611-de8f-412c-9ac2-3d77fb318e95" />
