### PR TITLE
Automagical StratumURL cleanup

### DIFF
--- a/main/http_server/axe-os/src/app/components/pool/pool.component.html
+++ b/main/http_server/axe-os/src/app/components/pool/pool.component.html
@@ -6,10 +6,9 @@
 
             <div class="card">
                 <div class="field grid p-fluid">
-                    <label [htmlFor]="pool + 'URL'" class="col-12 md:col-2 md:mb-0 md:pb-4">Stratum Host</label>
+                    <label [htmlFor]="pool + 'URL'" class="col-12 md:col-2 md:mb-0">Stratum Host</label>
                     <div class="col-12 md:col-10">
-                        <input pInputText type="text" [id]="pool + 'URL'" [formControlName]="pool + 'URL'" />
-                        <small>Do not include 'stratum+tcp://' or port.</small>
+                        <input pInputText type="text" [id]="pool + 'URL'" [formControlName]="pool + 'URL'" (change)="onUrlChange(pool)" />
                     </div>
                 </div>
                 <div class="field grid p-fluid">

--- a/main/http_server/axe-os/src/app/components/pool/pool.component.ts
+++ b/main/http_server/axe-os/src/app/components/pool/pool.component.ts
@@ -17,8 +17,8 @@ export class PoolComponent implements OnInit {
   public savedChanges: boolean = false;
 
   public pools: PoolType[] = ['stratum', 'fallbackStratum'];
-  public showPassword = {'stratum': false, 'fallbackStratum': false};
-  public showAdvancedOptions = {'stratum': false, 'fallbackStratum': false};
+  public showPassword = { 'stratum': false, 'fallbackStratum': false };
+  public showAdvancedOptions = { 'stratum': false, 'fallbackStratum': false };
 
   @Input() uri = '';
 
@@ -27,7 +27,7 @@ export class PoolComponent implements OnInit {
     private systemService: SystemService,
     private toastr: ToastrService,
     private loadingService: LoadingService
-  ) {}
+  ) { }
 
   ngOnInit(): void {
     this.systemService.getInfo(this.uri)
@@ -108,5 +108,36 @@ export class PoolComponent implements OnInit {
           this.toastr.error(errorMessage);
         }
       });
+  }
+
+  private extractPort(url: string): { cleanUrl: string, port?: number } {
+    const match = url.match(/:(\d{1,5})$/);
+    if (match) {
+      const port = parseInt(match[1], 10);
+      return { cleanUrl: url.slice(0, match.index), port };
+    }
+    return { cleanUrl: url };
+  }
+
+  public onUrlChange(poolType: PoolType) {
+    const urlControl = this.form.get(`${poolType}URL`);
+    const portControl = this.form.get(`${poolType}Port`);
+    if (!urlControl || !portControl) return;
+
+    let urlValue = urlControl.value || '';
+
+    if (!urlValue) return;
+
+    const prefix = 'stratum+tcp://';
+    if (urlValue.startsWith(prefix)) {
+      urlValue = urlValue.slice(prefix.length);
+    }
+
+    const { cleanUrl, port } = this.extractPort(urlValue);
+
+    if (port !== undefined) {
+      portControl.setValue(port);
+    }
+    urlControl.setValue(cleanUrl);
   }
 }


### PR DESCRIPTION
This PR ensures that Stratum(Fallback)URL is automatically transformed into the expected format (plain host). This means that any `stratum+tcp://` prefix is removed, if it exists. If the port is present, it is inserted into the corresponding (port) field.


https://github.com/user-attachments/assets/d90801d1-61c7-41c7-aec3-9bd978989f25

