### PR TITLE
Extend TPS546 detection code for other startup failures

### DIFF
--- a/main/power/TPS546.c
+++ b/main/power/TPS546.c
@@ -343,8 +343,10 @@ esp_err_t TPS546_init(TPS546_CONFIG config)
     ESP_LOGI(TAG, "Initializing the core voltage regulator");
     ESP_RETURN_ON_ERROR(i2c_bitaxe_add_device(TPS546_I2CADDR, &tps546_i2c_handle, TAG), TAG, "Failed to add TPS546 I2C");
 
+    // 1) Power-up guard (PMBus ready after AVIN UVLO + ~8 ms)
     vTaskDelay(pdMS_TO_TICKS(15));  // conservative
 
+    // 2) Robust ID read with retries
     uint8_t id[6] = {0};
     const int max_attempts = 6;
     bool id_matched = false;


### PR DESCRIPTION
On the Hex the TPS546 occasionally wasn't detected properly:
```
I (1353) TPS546: Initializing the core voltage regulator
I (1374) TPS546: Device ID: e8 7f ff ff ff ff
E (1374) TPS546: Cannot find TPS546 regulator - Device ID mismatch
```
Checking on 6x `0xff` failed, and the TPS546 won't init properly when this happens. It now retries against all known Device IDs. This PR also removes the `TPS546B` variant and fixes some compiler warnings.