### PR TITLE
Fix shares rejected reasons break

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -91,8 +91,8 @@
                     <span class="text-red-500 font-medium">0 </span>
                     <span class="text-500">rejected</span>
                 </div>
-                <div *ngIf="info.sharesRejected > 0">
-                    <ng-container *ngFor="let sharesRejectedReason of getSortedRejectionReasons(info); trackBy: trackByReason">
+                <ng-container *ngIf="info.sharesRejected > 0">
+                    <div *ngFor="let sharesRejectedReason of getSortedRejectionReasons(info); trackBy: trackByReason">
                         <span class="text-red-500 font-medium">
                             {{ sharesRejectedReason.count | number: '1.0-0' }}
                         </span>
@@ -103,8 +103,8 @@
                             [text]="'(' + (getShareRejectionPercentage(sharesRejectedReason, info) | number:'1.2-2') + ' %)'"
                             [tooltip]="getRejectionExplanation(sharesRejectedReason.message)"
                             [split]=false />
-                    </ng-container>
-                </div>
+                    </div>
+                </ng-container>
             </div>
         </div>
 


### PR DESCRIPTION
A small fix for missing break for shares rejected reasons on some breakpoints.

**Before**

<img width="984" height="221" alt="Before" src="https://github.com/user-attachments/assets/966e083b-2f62-4b9f-895c-2aa54fcfb1ff" />

**After**
<img width="979" height="215" alt="After" src="https://github.com/user-attachments/assets/e5576a84-10ab-46ba-a118-f03b001e90fe" />

