### PR TITLE
Shortened error percentage option

### DIFF
--- a/main/http_server/axe-os/src/models/enum/eChartLabel.ts
+++ b/main/http_server/axe-os/src/models/enum/eChartLabel.ts
@@ -1,7 +1,7 @@
 export enum eChartLabel {
     hashrate = 'Hashrate',
     asicTemp = 'ASIC Temp',
-    errorPercentage = 'Error Percentage',
+    errorPercentage = 'Error %',
     vrTemp = 'VR Temp',
     asicVoltage = 'ASIC Voltage',
     voltage = 'Voltage',


### PR DESCRIPTION
This small PR improves the dropdown option visibility, ensuring the value is fully visible without widening the dropdown.

**Before**
<img width="416" height="350" alt="Before" src="https://github.com/user-attachments/assets/9c206cc8-cadb-4816-b9be-5d65f5176f09" />

**After**
<img width="413" height="462" alt="Screenshot" src="https://github.com/user-attachments/assets/bf2b2bd2-a312-4884-a203-7f7243bc9493" />
