### PR TITLE
Increase z-index for tooltip backdrop

### DIFF
--- a/main/http_server/axe-os/src/app/components/tooltip-icon/tooltip-icon.component.scss
+++ b/main/http_server/axe-os/src/app/components/tooltip-icon/tooltip-icon.component.scss
@@ -14,7 +14,7 @@
         left: 0;
         right: 0;
         position: fixed;
-        z-index: 9;
+        z-index: 1000;
         display: flex;
         align-items: flex-end;
     }


### PR DESCRIPTION
This PR increases the z-index of the fullscreen tooltip backdrop so that the sidebar is also hidden. Seen on a Surface device.

**Before**
<img width="2092" height="1396" alt="Before" src="https://github.com/user-attachments/assets/1e009fcb-3f37-4294-85c9-e84948f6d017" />

**After**

<img width="2078" height="1390" alt="After" src="https://github.com/user-attachments/assets/d059e522-92cb-47af-8398-b5c49d361c7c" />


