### PR TITLE
Set suggested max for error percentage

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -682,6 +682,7 @@ export class HomeComponent implements OnInit, OnDestroy {
   public getSuggestedMaxForLabel(label: eChartLabel | undefined, info: ISystemInfo): number {
     switch (label) {
       case eChartLabel.hashrate:         return info.expectedHashrate;
+      case eChartLabel.errorPercentage:  return 1;
       case eChartLabel.asicTemp:         return this.maxTemp;
       case eChartLabel.vrTemp:           return this.maxTemp + 25;
       case eChartLabel.asicVoltage:      return info.coreVoltage;


### PR DESCRIPTION
This limits the size of the spikes when there's only a few errors.

<img width="1913" height="974" alt="image" src="https://github.com/user-attachments/assets/79474419-aeb0-484c-8339-096d9c8d72ee" />