### PR TITLE
Add HttpClient default timeout

### DIFF
--- a/main/http_server/axe-os/src/app/app.module.ts
+++ b/main/http_server/axe-os/src/app/app.module.ts
@@ -1,7 +1,7 @@
 import 'chartjs-adapter-moment';
 
 import { CommonModule, HashLocationStrategy, LocationStrategy } from '@angular/common';
-import { provideHttpClient } from '@angular/common/http';
+import { HTTP_INTERCEPTORS, provideHttpClient } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
@@ -37,6 +37,7 @@ import { TooltipModule } from 'primeng/tooltip';
 import { DialogModule } from 'primeng/dialog';
 import { DialogService as PrimeDialogService } from 'primeng/dynamicdialog';
 import { DialogService, DialogListComponent } from './services/dialog.service';
+import { TimeoutInterceptor } from './interceptors/timeout.interceptor';
 
 const components = [
   AppComponent,
@@ -88,6 +89,7 @@ const components = [
   ],
   providers: [
     { provide: LocationStrategy, useClass: HashLocationStrategy },
+    { provide: HTTP_INTERCEPTORS, useClass: TimeoutInterceptor, multi: true },
     DialogService,
     PrimeDialogService,
     provideHttpClient()

--- a/main/http_server/axe-os/src/app/interceptors/timeout.interceptor.ts
+++ b/main/http_server/axe-os/src/app/interceptors/timeout.interceptor.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { timeout } from 'rxjs/operators';
+
+@Injectable()
+export class TimeoutInterceptor implements HttpInterceptor {
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    return next.handle(req).pipe(
+      timeout(5000)
+    );
+  }
+}


### PR DESCRIPTION
On almost all AxeOS views, we use data pooling with a 5-second interval. Angular's `HttpClient` does not have a default timeout, which is not suitable for our purposes as we repeat a request after five seconds.

This PR sets a global timeout of 5 seconds. This value can be overwritten for any request if needed.