### PR TITLE
Fix: Decrease z-index of loading overlay

### DIFF
--- a/main/http_server/axe-os/src/app/components/loading/loading.component.scss
+++ b/main/http_server/axe-os/src/app/components/loading/loading.component.scss
@@ -1,10 +1,9 @@
 #loading {
     background-color: var(--maskbg);
-    left: calc(4rem + var(--sidebar-width));
 
     bottom: 0;
     position: fixed;
-    z-index: 99999999999999999999;
+    z-index: 9999;
 
     --padding: 2rem;
 


### PR DESCRIPTION
In some cases, the loading overlay and toaster notifications may be displayed simultaneously. Currently, notifications are masked by the layer. This PR ensures that the layer is assigned a lower (z-)index.

**Before**
<img width="2584" height="1536" alt="Before" src="https://github.com/user-attachments/assets/50d303f6-b71a-4190-8a8e-aa7d4b517c78" />

**After**
<img width="2584" height="1536" alt="After" src="https://github.com/user-attachments/assets/c467e617-a9ad-46a4-adec-a7c19464eac6" />

