### PR TITLE
Add difficulty tooltip to show full number

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -419,7 +419,7 @@
                     <div class="col-fixed-width text-500">
                         <span>Difficulty</span>
                     </div>
-                    <div *ngIf="info.networkDifficulty">
+                    <div *ngIf="info.networkDifficulty" class="cursor-pointer" pTooltip="{{info.networkDifficulty | number:'1.0-0'}}" tooltipPosition="bottom">
                         {{ info.networkDifficulty | diffSuffix }}
                     </div>
                 </div>


### PR DESCRIPTION
This PR replaces the outdated https://github.com/bitaxeorg/ESP-Miner/pull/805
It adds a tooltip for the achieved difficulties. On hover non suffixed numbers are shown.

**Device difficulty**
<img width="592" alt="Device difficulty 1" src="https://github.com/user-attachments/assets/9fdf04c8-0a08-4e4d-b4ee-e4fc4fc0e9e4" />

<img width="575" alt="Device difficulty 2" src="https://github.com/user-attachments/assets/c025d3d3-1c73-4e7f-b74c-499d85a5b044" />

**Network difficulty**
<img width="358" alt="Network difficulty" src="https://github.com/user-attachments/assets/00d99896-9880-46a5-a98e-b03cedce519a" />
