### PR TITLE
Bring back uptime

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -173,7 +173,7 @@
                         {{info.bestSessionDiff | diffSuffix}}
                     </span>
                     <span class="text-500 text-lg">session best</span>
-                    <span class="text-sm font-medium mb-3"> ({{ info.uptimeSeconds | dateAgo: { intervals: 2, strict:true } }})</span>
+                    <span class="text-sm font-medium mb-3"> ({{ info.uptimeSeconds | dateAgo: { intervals: 2, strict:true, short:true } }})</span>
                 </div>
             </div>
         </div>

--- a/main/http_server/axe-os/src/app/pipes/date-ago.pipe.ts
+++ b/main/http_server/axe-os/src/app/pipes/date-ago.pipe.ts
@@ -32,15 +32,9 @@ export class DateAgoPipe implements PipeTransform {
         if (args?.intervals && shownIntervals >= args.intervals) break;
         const counter = Math.floor(seconds / intervals[i]);
         if (counter > 0) {
-          if (counter === 1) {
-            if (result) result += ', '
-            result += counter + ' ' + i + ''; // singular (1 day ago)
-            seconds -= intervals[i]
-          } else {
-            if (result) result += ', '
-            result += counter + ' ' + i + 's'; // plural (2 days ago)
-            seconds -= intervals[i] * counter
-          }
+          if (result) result += args?.short ? ' ' : ', ';
+          result += counter + (args?.short ? i[0] : ' ' + i + (counter > 1 ? 's' : ''));
+          seconds -= intervals[i] * counter
           shownIntervals++;
         }
       }


### PR DESCRIPTION
Due to popular request, uptime is back on the dashboard. Found a little nook to put it that made.

<img width="481" height="231" alt="image" src="https://github.com/user-attachments/assets/384d4fa0-dc21-49ef-813e-b7d72eedca78" />

Also slightly increased the font size of the tiny statistics:
<img width="951" height="238" alt="image" src="https://github.com/user-attachments/assets/cb7fa8e9-16bb-43e5-abd1-58ac8bb5396a" />

#1427.
#1356.
#1355.