### PR TITLE
Add custom icon to <tooltip-text-icon> component

### DIFF
--- a/main/http_server/axe-os/src/app/components/tooltip-icon/tooltip-icon.component.ts
+++ b/main/http_server/axe-os/src/app/components/tooltip-icon/tooltip-icon.component.ts
@@ -8,8 +8,12 @@ import { Component, Input, HostListener } from '@angular/core';
 export class TooltipIconComponent {
   @Input() tooltip: string = '';
   @Input() size: string = 'xs';
+  @Input() icon: string = '';
 
   showMobileTooltip = false;
-  tooltipIconClass = `pi pi-question-circle text-${this.size} pl-1 pr-2 tooltip-icon`;
   isMobile = ('ontouchstart' in window) || (navigator.maxTouchPoints > 0);
+
+  get tooltipIconClass(): string {
+    return `pi ${this.icon} text-${this.size} pl-1 pr-2 tooltip-icon`;
+  }
 }

--- a/main/http_server/axe-os/src/app/components/tooltip-text-icon/tooltip-text-icon.component.html
+++ b/main/http_server/axe-os/src/app/components/tooltip-text-icon/tooltip-text-icon.component.html
@@ -3,13 +3,13 @@
         <span *ngIf="preLastWords">{{ preLastWords }}&nbsp;</span>
 
         <span class="white-space-nowrap">
-            {{ lastWord }}<tooltip-icon [tooltip]="tooltip" />
+            {{ lastWord }}<tooltip-icon [tooltip]="tooltip" [icon]="icon" />
         </span>
     </ng-container>
 
     <ng-template #noSplit>
         <span class="white-space-nowrap">
-            {{ text }}<tooltip-icon [tooltip]="tooltip" />
+            {{ text }}<tooltip-icon [tooltip]="tooltip" [icon]="icon" />
         </span>
     </ng-template>
 </ng-container>

--- a/main/http_server/axe-os/src/app/components/tooltip-text-icon/tooltip-text-icon.component.ts
+++ b/main/http_server/axe-os/src/app/components/tooltip-text-icon/tooltip-text-icon.component.ts
@@ -6,6 +6,7 @@ import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 })
 export class TooltipTextIconComponent implements OnChanges {
   @Input() tooltip: string | null = '';
+  @Input() icon: string = 'pi-question-circle';
   @Input() text: string | null = '';
   @Input() split: boolean = true;
 


### PR DESCRIPTION
This PR adds the ability to pass the desired icon to the `<tooltip-text-icon>` component. `pi-question-circle` remains the default.

```
<tooltip-text-icon
    text="URL"
    tooltip="{{ getPoolProtocolType(info) }}"
    icon="pi-info-circle"
/>
```

Closes https://github.com/bitaxeorg/ESP-Miner/issues/1412