### PR TITLE
Fix possible out-of-bounds write

### DIFF
--- a/components/stratum/test/test_utils.c
+++ b/components/stratum/test/test_utils.c
@@ -29,7 +29,8 @@ TEST_CASE("Test bin2hex", "[utils]")
 {
     uint8_t bin[5] = {72, 69, 76, 76, 79};
     char hex_string[11];
-    bin2hex(bin, 5, hex_string, 11);
+    TEST_ASSERT_EQUAL(0, bin2hex(bin, 5, hex_string, 10));
+    TEST_ASSERT_EQUAL(10, bin2hex(bin, 5, hex_string, 11));
     TEST_ASSERT_EQUAL_STRING("48454c4c4f", hex_string);
 }
 

--- a/components/stratum/utils.c
+++ b/components/stratum/utils.c
@@ -19,7 +19,7 @@ static const uint8_t hex_val_table[256] = {
 
 size_t bin2hex(const uint8_t *buf, size_t buflen, char *hex, size_t hexlen)
 {
-    if (hexlen < buflen * 2) {
+    if (hexlen <= buflen * 2) {
         return 0;
     }
 


### PR DESCRIPTION
The util function bin2hex writes a null-terminated string and should check the length of the destination buffer including the null-termination.