### PR TITLE
Single options request handler for API

### DIFF
--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -1266,6 +1266,14 @@ esp_err_t start_rest_server(void * pvParameters)
     ESP_LOGI(TAG, "Starting HTTP Server");
     REST_CHECK(httpd_start(&server, &config) == ESP_OK, "Start server failed", err_start);
 
+    httpd_uri_t api_options_uri = {
+        .uri = "/api/*", 
+        .method = HTTP_OPTIONS, 
+        .handler = handle_options_request, 
+        .user_ctx = NULL
+    };
+    httpd_register_uri_handler(server, &api_options_uri);
+
     httpd_uri_t recovery_explicit_get_uri = {
         .uri = "/recovery", 
         .method = HTTP_GET, 
@@ -1320,28 +1328,12 @@ esp_err_t start_rest_server(void * pvParameters)
     };
     httpd_register_uri_handler(server, &system_identify_uri);
 
-    httpd_uri_t system_identify_options_uri = {
-        .uri = "/api/system/identify", 
-        .method = HTTP_OPTIONS, 
-        .handler = handle_options_request, 
-        .user_ctx = NULL
-    };
-    httpd_register_uri_handler(server, &system_identify_options_uri);
-
     httpd_uri_t system_restart_uri = {
         .uri = "/api/system/restart", .method = HTTP_POST, 
         .handler = POST_restart, 
         .user_ctx = rest_context
     };
     httpd_register_uri_handler(server, &system_restart_uri);
-
-    httpd_uri_t system_restart_options_uri = {
-        .uri = "/api/system/restart", 
-        .method = HTTP_OPTIONS, 
-        .handler = handle_options_request, 
-        .user_ctx = NULL
-    };
-    httpd_register_uri_handler(server, &system_restart_options_uri);
 
     httpd_uri_t update_system_settings_uri = {
         .uri = "/api/system", 
@@ -1350,14 +1342,6 @@ esp_err_t start_rest_server(void * pvParameters)
         .user_ctx = rest_context
     };
     httpd_register_uri_handler(server, &update_system_settings_uri);
-
-    httpd_uri_t system_options_uri = {
-        .uri = "/api/system",
-        .method = HTTP_OPTIONS,
-        .handler = handle_options_request,
-        .user_ctx = NULL,
-    };
-    httpd_register_uri_handler(server, &system_options_uri);
 
     httpd_uri_t update_post_ota_firmware = {
         .uri = "/api/system/OTA", 

--- a/main/http_server/theme_api.c
+++ b/main/http_server/theme_api.c
@@ -16,14 +16,6 @@ static esp_err_t set_cors_headers(httpd_req_t *req)
     return ESP_OK;
 }
 
-// Handle OPTIONS requests for CORS
-static esp_err_t theme_options_handler(httpd_req_t *req)
-{
-    set_cors_headers(req);
-    httpd_resp_send(req, NULL, 0);
-    return ESP_OK;
-}
-
 // GET /api/theme handler
 static esp_err_t theme_get_handler(httpd_req_t *req)
 {
@@ -104,16 +96,8 @@ esp_err_t register_theme_api_endpoints(httpd_handle_t server, void* ctx)
         .user_ctx = ctx
     };
 
-    httpd_uri_t theme_options = {
-        .uri = "/api/theme",
-        .method = HTTP_OPTIONS,
-        .handler = theme_options_handler,
-        .user_ctx = ctx
-    };
-
     ESP_ERROR_CHECK(httpd_register_uri_handler(server, &theme_get));
     ESP_ERROR_CHECK(httpd_register_uri_handler(server, &theme_post));
-    ESP_ERROR_CHECK(httpd_register_uri_handler(server, &theme_options));
 
     return ESP_OK;
 }


### PR DESCRIPTION
No need to define separate options handlers for each API path.