### PR TITLE
Graph the hottest ASIC temp for multi chip units

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -760,7 +760,13 @@ export class HomeComponent implements OnInit, OnDestroy {
       case eChartLabel.hashrate_10m:       return info.hashRate_10m;
       case eChartLabel.hashrate_1h:        return info.hashRate_1h;
       case eChartLabel.errorPercentage:    return info.errorPercentage;
-      case eChartLabel.asicTemp:           return info.temp;
+      case eChartLabel.asicTemp:
+        switch (true) {                    // we want to show to hottest asic temp on the graph
+          case info.temp2 > info.temp:
+            return info.temp2;
+          default:
+            return info.temp; 
+        }
       case eChartLabel.vrTemp:             return info.vrTemp;
       case eChartLabel.asicVoltage:        return info.coreVoltageActual;
       case eChartLabel.voltage:            return info.voltage;


### PR DESCRIPTION
This PR addresses issue "ASIC Temp chart misleading on multi chip units #1476". Currently the graph chart ASIC #1 on a multi chip unit. The PR charts the hottest ASIC temp. This change was tested on a 601 and 801