### PR TITLE
Guard active_jobs with valid_jobs_lock

### DIFF
--- a/components/asic/bm1366.c
+++ b/components/asic/bm1366.c
@@ -293,13 +293,12 @@ void BM1366_send_work(void * pvParameters, bm_job * next_bm_job)
     memcpy(job.prev_block_hash, next_bm_job->prev_block_hash, 32);
     memcpy(&job.version, &next_bm_job->version, 4);
 
+    pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
     if (GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job.job_id] != NULL) {
         free_bm_job(GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job.job_id]);
     }
 
     GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job.job_id] = next_bm_job;
-
-    pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
     GLOBAL_STATE->valid_jobs[job.job_id] = 1;
     pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
 
@@ -343,12 +342,18 @@ task_result * BM1366_process_work(void * pvParameters)
 
     GlobalState * GLOBAL_STATE = (GlobalState *) pvParameters;
 
-    if (GLOBAL_STATE->valid_jobs[job_id] == 0) {
+    uint32_t base_version = 0;
+    pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
+    if (GLOBAL_STATE->valid_jobs[job_id] == 0 || GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id] == NULL) {
+        pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
         ESP_LOGW(TAG, "Invalid job nonce found, 0x%02X", job_id);
         return NULL;
     }
 
-    uint32_t rolled_version = GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id]->version | version_bits;
+    base_version = GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id]->version;
+    pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
+
+    uint32_t rolled_version = base_version | version_bits;
 
     result.job_id = job_id;
     result.nonce = asic_result.job.nonce;

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -313,13 +313,12 @@ void BM1370_send_work(void * pvParameters, bm_job * next_bm_job)
     memcpy(job.prev_block_hash, next_bm_job->prev_block_hash, 32);
     memcpy(&job.version, &next_bm_job->version, 4);
 
+    pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
     if (GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job.job_id] != NULL) {
         free_bm_job(GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job.job_id]);
     }
 
     GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job.job_id] = next_bm_job;
-
-    pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
     GLOBAL_STATE->valid_jobs[job.job_id] = 1;
     pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
 
@@ -363,12 +362,18 @@ task_result * BM1370_process_work(void * pvParameters)
 
     GlobalState * GLOBAL_STATE = (GlobalState *) pvParameters;
 
-    if (GLOBAL_STATE->valid_jobs[job_id] == 0) {
+    uint32_t base_version = 0;
+    pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
+    if (GLOBAL_STATE->valid_jobs[job_id] == 0 || GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id] == NULL) {
+        pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
         ESP_LOGW(TAG, "Invalid job nonce found, 0x%02X", job_id);
         return NULL;
     }
 
-    uint32_t rolled_version = GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id]->version | version_bits;
+    base_version = GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id]->version;
+    pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
+
+    uint32_t rolled_version = base_version | version_bits;
 
     result.job_id = job_id;
     result.nonce = asic_result.job.nonce;

--- a/main/tasks/asic_result_task.c
+++ b/main/tasks/asic_result_task.c
@@ -40,31 +40,60 @@ void ASIC_result_task(void *pvParameters)
 
         uint8_t job_id = asic_result->job_id;
 
-        if (GLOBAL_STATE->valid_jobs[job_id] == 0)
+        bm_job job_snapshot = {0};
+        char *jobid_copy = NULL;
+        char *extranonce2_copy = NULL;
+        uint32_t pool_diff = 0;
+        uint32_t job_version = 0;
+        uint32_t job_ntime = 0;
+        bool should_submit = false;
+
+        pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
+        if (GLOBAL_STATE->valid_jobs[job_id] == 0 || GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id] == NULL)
         {
+            pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
             ESP_LOGW(TAG, "Invalid job nonce found, 0x%02X", job_id);
             continue;
         }
 
         bm_job *active_job = GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id];
+        job_snapshot = *active_job;
+        pool_diff = active_job->pool_diff;
+        job_version = active_job->version;
+        job_ntime = active_job->ntime;
+
         // check the nonce difficulty
-        double nonce_diff = test_nonce_value(active_job, asic_result->nonce, asic_result->rolled_version);
+        double nonce_diff = test_nonce_value(&job_snapshot, asic_result->nonce, asic_result->rolled_version);
 
         //log the ASIC response
-        ESP_LOGI(TAG, "ID: %s, ASIC nr: %d, ver: %08" PRIX32 " Nonce %08" PRIX32 " diff %.1f of %ld.", active_job->jobid, asic_result->asic_nr, asic_result->rolled_version, asic_result->nonce, nonce_diff, active_job->pool_diff);
+        ESP_LOGI(TAG, "ID: %s, ASIC nr: %d, ver: %08" PRIX32 " Nonce %08" PRIX32 " diff %.1f of %ld.", active_job->jobid, asic_result->asic_nr, asic_result->rolled_version, asic_result->nonce, nonce_diff, pool_diff);
 
-        if (nonce_diff >= active_job->pool_diff)
+        if (nonce_diff >= pool_diff)
+        {
+            if (active_job->jobid != NULL) {
+                jobid_copy = strdup(active_job->jobid);
+            }
+            if (active_job->extranonce2 != NULL) {
+                extranonce2_copy = strdup(active_job->extranonce2);
+            }
+            should_submit = true;
+        }
+
+        SYSTEM_notify_found_nonce(GLOBAL_STATE, nonce_diff, job_id);
+        pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
+
+        if (should_submit && jobid_copy != NULL && extranonce2_copy != NULL)
         {
             char * user = GLOBAL_STATE->SYSTEM_MODULE.is_using_fallback ? GLOBAL_STATE->SYSTEM_MODULE.fallback_pool_user : GLOBAL_STATE->SYSTEM_MODULE.pool_user;
             int ret = STRATUM_V1_submit_share(
                 GLOBAL_STATE->transport,
                 GLOBAL_STATE->send_uid++,
                 user,
-                active_job->jobid,
-                active_job->extranonce2,
-                active_job->ntime,
+                jobid_copy,
+                extranonce2_copy,
+                job_ntime,
                 asic_result->nonce,
-                asic_result->rolled_version ^ active_job->version);
+                asic_result->rolled_version ^ job_version);
 
             if (ret < 0) {
                 ESP_LOGI(TAG, "Unable to write share to socket. Closing connection. Ret: %d (errno %d: %s)", ret, errno, strerror(errno));
@@ -72,6 +101,7 @@ void ASIC_result_task(void *pvParameters)
             }
         }
 
-        SYSTEM_notify_found_nonce(GLOBAL_STATE, nonce_diff, job_id);
+        free(jobid_copy);
+        free(extranonce2_copy);
     }
 }


### PR DESCRIPTION
submitted by mistake