### PR TITLE
statistics_task: use uint64_t timestamps to prevent 32-bit overflow

### DIFF
--- a/main/tasks/statistics_task.c
+++ b/main/tasks/statistics_task.c
@@ -119,12 +119,12 @@ void statistics_task(void * pvParameters)
     TickType_t taskWakeTime = xTaskGetTickCount();
 
     while (1) {
-        const int32_t currentTime = esp_timer_get_time() / 1000;
+        const uint64_t currentTime = esp_timer_get_time() / 1000;
         const uint16_t configStatsFrequency = nvs_config_get_u16(NVS_CONFIG_STATISTICS_FREQUENCY);
-        const uint32_t statsFrequency = configStatsFrequency * 1000;
+        const uint64_t statsFrequency = (uint64_t)configStatsFrequency * 1000;
 
         if (0 != statsFrequency) {
-            const int32_t waitingTime = statsData.timestamp + statsFrequency - (DEFAULT_POLL_RATE / 2);
+            const uint64_t waitingTime = statsData.timestamp + statsFrequency - (DEFAULT_POLL_RATE / 2);
 
             if (currentTime > waitingTime) {
                 int8_t wifiRSSI = -90;

--- a/main/tasks/statistics_task.h
+++ b/main/tasks/statistics_task.h
@@ -1,11 +1,13 @@
 #ifndef STATISTICS_TASK_H_
 #define STATISTICS_TASK_H_
 
+#include <stdint.h>
+
 typedef struct StatisticsData * StatisticsDataPtr;
 
 struct StatisticsData
 {
-    uint32_t timestamp;
+    uint64_t timestamp;
     float hashrate;
     float hashrate_1m;
     float hashrate_10m;


### PR DESCRIPTION
The currentTime is in **ms** and it overflows after about 24 days, 20 hours, 31 minutes with int32_t.

<img width="1467" height="657" alt="Screenshot 2026-02-07" src="https://github.com/user-attachments/assets/d45fc641-9735-45bb-87fb-e0488dade6b1" />

Making it an uint64_t should fix that.


