### PR TITLE
Check if the address is in the same /24 network as the device's IP

### DIFF
--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -222,6 +222,19 @@ static esp_err_t ip_in_private_range(uint32_t address) {
         return ESP_OK;
     }
 
+    // Check if the address is in the same /24 network as the device's IP
+    // This allows non-standard private networks (e.g., if device has 23.33.0.111, allow 23.33.0.*)
+    if (GLOBAL_STATE != NULL && GLOBAL_STATE->SYSTEM_MODULE.ip_addr_str[0] != '\0') {
+        uint32_t device_ip_addr = inet_addr(GLOBAL_STATE->SYSTEM_MODULE.ip_addr_str);
+        if (device_ip_addr != INADDR_NONE) {
+            uint32_t device_ip = ntohl(device_ip_addr);
+            // Compare the first 24 bits (network portion for /24 subnet)
+            if ((ip_address & 0xFFFFFF00) == (device_ip & 0xFFFFFF00)) {
+                return ESP_OK;
+            }
+        }
+    }
+
     return ESP_FAIL;
 }
 


### PR DESCRIPTION
Allow non-standard private networks other than 10.0.0.0 - 10.255.255.255, 172.16.0.0 - 172.31.255.255 and 192.168.0.0 - 192.168.255.255 