### PR TITLE
Update the defaults for 650 duo to 400mhz

### DIFF
--- a/main/device_config.h
+++ b/main/device_config.h
@@ -39,6 +39,7 @@ typedef enum
     HEX,
     SUPRA,
     GAMMA,
+    GAMMA_DUO,
     SUPRA_HEX,
     GAMMA_TURBO,
 } Family;


### PR DESCRIPTION
The 650 duo uses S21 XP chips which have a lower default clock. The UI should update the dropdown to show default as 400mhz