### PR TITLE
Add client.reconnect hostname/port/waittime support

### DIFF
--- a/components/stratum/include/stratum_api.h
+++ b/components/stratum/include/stratum_api.h
@@ -68,6 +68,10 @@ typedef struct
     uint32_t new_difficulty;
     // mining.set_version_mask
     uint32_t version_mask;
+    // client.reconnect
+    char * reconnect_hostname;
+    int reconnect_port;
+    int reconnect_wait;
     // result
     bool response_success;
     char * error_str;
@@ -105,5 +109,7 @@ int STRATUM_V1_submit_share(esp_transport_handle_t transport, int send_uid, cons
                             const uint32_t version_bits);
 
 float STRATUM_V1_get_response_time_ms(int request_id, int64_t receive_time_us);
+
+bool is_same_domain(const char * host_a, const char * host_b);
 
 #endif // STRATUM_API_H

--- a/components/stratum/stratum_api.c
+++ b/components/stratum/stratum_api.c
@@ -223,6 +223,21 @@ void STRATUM_V1_parse(StratumApiV1Message * message, const char * stratum_json)
             result = MINING_SET_EXTRANONCE;
         } else if (strcmp("client.reconnect", method_json->valuestring) == 0) {
             result = CLIENT_RECONNECT;
+            cJSON * params = cJSON_GetObjectItem(json, "params");
+            if (params != NULL && cJSON_IsArray(params)) {
+                cJSON * hostname = cJSON_GetArrayItem(params, 0);
+                cJSON * port_json = cJSON_GetArrayItem(params, 1);
+                cJSON * wait_json = cJSON_GetArrayItem(params, 2);
+                if (hostname != NULL && cJSON_IsString(hostname) && strlen(hostname->valuestring) > 0) {
+                    message->reconnect_hostname = strdup(hostname->valuestring);
+                }
+                if (port_json != NULL && cJSON_IsNumber(port_json) && port_json->valueint > 0) {
+                    message->reconnect_port = port_json->valueint;
+                }
+                if (wait_json != NULL && cJSON_IsNumber(wait_json) && wait_json->valueint > 0) {
+                    message->reconnect_wait = wait_json->valueint;
+                }
+            }
         } else if (strcmp("mining.ping", method_json->valuestring) == 0) {
             result = MINING_PING;
         } else {
@@ -533,4 +548,36 @@ int STRATUM_V1_configure_version_rolling(esp_transport_handle_t transport, int s
     debug_stratum_tx(configure_msg);
 
     return esp_transport_write(transport, configure_msg, strlen(configure_msg), TRANSPORT_TIMEOUT_MS);
+}
+
+bool is_same_domain(const char * host_a, const char * host_b)
+{
+    if (host_a == NULL || host_b == NULL) return false;
+    if (strcmp(host_a, host_b) == 0) return true;
+
+    size_t len_a = strlen(host_a);
+    size_t len_b = strlen(host_b);
+
+    // Check if one is a subdomain of the other
+    if (len_a > len_b + 1 && host_a[len_a - len_b - 1] == '.' &&
+        strcmp(host_a + len_a - len_b, host_b) == 0 &&
+        strchr(host_b, '.') != NULL) {
+        return true;
+    }
+    if (len_b > len_a + 1 && host_b[len_b - len_a - 1] == '.' &&
+        strcmp(host_b + len_b - len_a, host_a) == 0 &&
+        strchr(host_a, '.') != NULL) {
+        return true;
+    }
+
+    // Check same-depth siblings
+    const char * suffix_a = strchr(host_a, '.');
+    const char * suffix_b = strchr(host_b, '.');
+    if (suffix_a != NULL && suffix_b != NULL &&
+        strchr(suffix_a + 1, '.') != NULL &&
+        strcmp(suffix_a, suffix_b) == 0) {
+        return true;
+    }
+
+    return false;
 }

--- a/components/stratum/test/test_stratum_json.c
+++ b/components/stratum/test/test_stratum_json.c
@@ -207,3 +207,38 @@ TEST_CASE("Parse stratum error array format", "[stratum]")
     TEST_ASSERT_FALSE(stratum_api_v1_message.response_success);
     TEST_ASSERT_EQUAL_STRING("Job not found", stratum_api_v1_message.error_str);
 }
+
+TEST_CASE("Parse client.reconnect with all params", "[stratum]")
+{
+    StratumApiV1Message msg = {};
+    const char *json_string = "{\"id\":null,\"method\":\"client.reconnect\",\"params\":[\"us1.pool.example.com\",3333,5]}";
+    STRATUM_V1_parse(&msg, json_string);
+    TEST_ASSERT_EQUAL(CLIENT_RECONNECT, msg.method);
+    TEST_ASSERT_EQUAL_STRING("us1.pool.example.com", msg.reconnect_hostname);
+    TEST_ASSERT_EQUAL(3333, msg.reconnect_port);
+    TEST_ASSERT_EQUAL(5, msg.reconnect_wait);
+    free(msg.reconnect_hostname);
+}
+
+TEST_CASE("Parse client.reconnect with no params", "[stratum]")
+{
+    StratumApiV1Message msg = {};
+    const char *json_string = "{\"id\":null,\"method\":\"client.reconnect\"}";
+    STRATUM_V1_parse(&msg, json_string);
+    TEST_ASSERT_EQUAL(CLIENT_RECONNECT, msg.method);
+    TEST_ASSERT_NULL(msg.reconnect_hostname);
+    TEST_ASSERT_EQUAL(0, msg.reconnect_port);
+    TEST_ASSERT_EQUAL(0, msg.reconnect_wait);
+}
+
+TEST_CASE("is_same_domain allows subdomain", "[stratum]")
+{
+    TEST_ASSERT_TRUE(is_same_domain("us1.pool.example.com", "pool.example.com"));
+    TEST_ASSERT_TRUE(is_same_domain("pool.example.com", "us1.pool.example.com"));
+}
+
+TEST_CASE("is_same_domain rejects different domain", "[stratum]")
+{
+    TEST_ASSERT_FALSE(is_same_domain("evil.com", "pool.example.com"));
+    TEST_ASSERT_FALSE(is_same_domain("pool.example.com.evil.com", "pool.example.com"));
+}

--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -438,6 +438,8 @@ void stratum_task(void * pvParameters)
     STRATUM_V1_initialize_buffer();
     int retry_attempts = 0;
     int retry_critical_attempts = 0;
+    bool reconnect_override = false;
+    char * reconnect_hostname_alloc = NULL;
 
     xTaskCreateWithCaps(stratum_primary_heartbeat, "stratum primary heartbeat", 8192, pvParameters, 1, NULL, MALLOC_CAP_SPIRAM);
 
@@ -479,8 +481,14 @@ void stratum_task(void * pvParameters)
             retry_attempts = 0;
         }
 
-        stratum_url = GLOBAL_STATE->SYSTEM_MODULE.is_using_fallback ? GLOBAL_STATE->SYSTEM_MODULE.fallback_pool_url : GLOBAL_STATE->SYSTEM_MODULE.pool_url;
-        port = GLOBAL_STATE->SYSTEM_MODULE.is_using_fallback ? GLOBAL_STATE->SYSTEM_MODULE.fallback_pool_port : GLOBAL_STATE->SYSTEM_MODULE.pool_port;
+        if (reconnect_override) {
+            reconnect_override = false;
+        } else {
+            free(reconnect_hostname_alloc);
+            reconnect_hostname_alloc = NULL;
+            stratum_url = GLOBAL_STATE->SYSTEM_MODULE.is_using_fallback ? GLOBAL_STATE->SYSTEM_MODULE.fallback_pool_url : GLOBAL_STATE->SYSTEM_MODULE.pool_url;
+            port = GLOBAL_STATE->SYSTEM_MODULE.is_using_fallback ? GLOBAL_STATE->SYSTEM_MODULE.fallback_pool_port : GLOBAL_STATE->SYSTEM_MODULE.pool_port;
+        }
         extranonce_subscribe = GLOBAL_STATE->SYSTEM_MODULE.is_using_fallback ? GLOBAL_STATE->SYSTEM_MODULE.fallback_pool_extranonce_subscribe : GLOBAL_STATE->SYSTEM_MODULE.pool_extranonce_subscribe;
         difficulty = GLOBAL_STATE->SYSTEM_MODULE.is_using_fallback ? GLOBAL_STATE->SYSTEM_MODULE.fallback_pool_difficulty : GLOBAL_STATE->SYSTEM_MODULE.pool_difficulty;
 
@@ -617,8 +625,36 @@ void stratum_task(void * pvParameters)
             } else if (stratum_api_v1_message.method == MINING_PING) { 
                 STRATUM_V1_pong(GLOBAL_STATE->transport, stratum_api_v1_message.message_id);
             } else if (stratum_api_v1_message.method == CLIENT_RECONNECT) {
-                ESP_LOGE(TAG, "Pool requested client reconnect...");
+                ESP_LOGI(TAG, "Pool requested client reconnect...");
+
+                if (stratum_api_v1_message.reconnect_hostname != NULL) {
+                    const char * req_host = stratum_api_v1_message.reconnect_hostname;
+                    bool allowed = is_same_domain(req_host, GLOBAL_STATE->SYSTEM_MODULE.pool_url);
+                    if (!allowed) {
+                        allowed = is_same_domain(req_host, GLOBAL_STATE->SYSTEM_MODULE.fallback_pool_url);
+                    }
+                    if (allowed) {
+                        free(reconnect_hostname_alloc);
+                        reconnect_hostname_alloc = stratum_api_v1_message.reconnect_hostname;
+                        stratum_api_v1_message.reconnect_hostname = NULL;
+                        stratum_url = reconnect_hostname_alloc;
+                        ESP_LOGI(TAG, "Reconnect: using hostname %s", stratum_url);
+                    } else {
+                        ESP_LOGW(TAG, "Reconnect: ignoring disallowed hostname %s", req_host);
+                    }
+                }
+                if (stratum_api_v1_message.reconnect_port > 0) {
+                    port = stratum_api_v1_message.reconnect_port;
+                    ESP_LOGI(TAG, "Reconnect: using port %d", port);
+                }
+
+                reconnect_override = true;
                 stratum_close_connection(GLOBAL_STATE);
+
+                if (stratum_api_v1_message.reconnect_wait > 0) {
+                    ESP_LOGI(TAG, "Reconnect: waiting %d seconds", stratum_api_v1_message.reconnect_wait);
+                    vTaskDelay((stratum_api_v1_message.reconnect_wait * 1000) / portTICK_PERIOD_MS);
+                }
                 break;
             } else if (stratum_api_v1_message.method == STRATUM_RESULT) {
                 if (stratum_api_v1_message.response_success) {
@@ -654,6 +690,10 @@ void stratum_task(void * pvParameters)
         if (stratum_api_v1_message.error_str) {
             free(stratum_api_v1_message.error_str);
             stratum_api_v1_message.error_str = NULL;
+        }
+        if (stratum_api_v1_message.reconnect_hostname) {
+            free(stratum_api_v1_message.reconnect_hostname);
+            stratum_api_v1_message.reconnect_hostname = NULL;
         }
     }
     vTaskDelete(NULL);


### PR DESCRIPTION
Parse optional params from client.reconnect messages per the stratum protocol spec. The client disconnects, waits the requested time, then reconnects to the specified host/port. Hostname defaults to the current server and is validated against the configured pool domain (including subdomains) to prevent redirection to unrelated servers.

Added Params:
- Hostname - Allows a pool to redirect a miner to a different instance behind a DNS load balancer, or to a geographically closer / better-peered server for improved latency
- Port - Enables moving miners between difficulty-tier ports (ex. redirecting a high-hashrate device that mistakenly connected to a low-diff port)
- Waittime - Gives the pool control over reconnection timing, useful for staggering reconnects during server maintenance to avoid a thundering herd of simultaneous connections

Cases and what I believe the correct resolution is:
- No params
  - {"method":"client.reconnect"}
  - Reconnect as previously defined
- Hostname-only
  - {"method":"client.reconnect","params":["us1.pool.example.com"]}
  - Reconnect to specified host IF it shares a domain with the current server ELSE use the configured server instead
- Port-only
  - {"method":"client.reconnect","params":["",8333]}
  - Reconnect to the configured server on the specified port
- Waittime-only
  - {"method":"client.reconnect","params":["",0,30]}
  - Disconnect, wait the specified time, then reconnect to the configured server
- Hostname + port
  - {"method":"client.reconnect","params":["us1.pool.example.com",8333]}
  - Reconnect to specified host:port IF hostname shares a domain ELSE use the configured server on the specified port
- Hostname + waittime
  - {"method":"client.reconnect","params":["us1.pool.example.com",0,30]}
  - Disconnect, wait, then reconnect to specified host IF hostname shares a domain ELSE use the configured server
- Port + waittime
  - {"method":"client.reconnect","params":["",8333,30]}
  - Disconnect, wait, then reconnect to the configured server on the specified port
- All three
  - {"method":"client.reconnect","params":["us1.pool.example.com",8333,30]}
  - Disconnect, wait, then reconnect to specified host:port IF hostname shares a domain ELSE use the configured server on the specified port